### PR TITLE
Jira-only mode + Clockify/Jira disable toggles

### DIFF
--- a/dashboard/routes/calendar.ts
+++ b/dashboard/routes/calendar.ts
@@ -3,6 +3,7 @@ import { google } from 'googleapis';
 import { getAuthenticatedClient, getRefreshedToken } from '../../lib/google.js';
 import { getLatestToken, storeToken, getEventProject, setEventProject, getActiveProjects } from '../../lib/db.js';
 import { Clockify } from '../../clockify.js';
+import { isClockifyEnabled } from '../../lib/credentials.js';
 
 // Hardcoded — registered with Google OAuth; cannot vary with CLOCKTOPUS_PORT
 // without re-registering the redirect URI in the Google Cloud console.
@@ -11,6 +12,9 @@ const DASHBOARD_REDIRECT_URI = 'http://localhost:4001/api/google/callback';
 const calendarRoutes = new Hono();
 
 calendarRoutes.get('/calendar/events', async (c) => {
+  if (!isClockifyEnabled()) {
+    return c.json({ ok: false, error: 'Calendar sync requires Clockify.' }, 400);
+  }
   const start = c.req.query('start');
   const end = c.req.query('end');
 
@@ -107,6 +111,9 @@ calendarRoutes.get('/calendar/events', async (c) => {
 });
 
 calendarRoutes.post('/calendar/log', async (c) => {
+  if (!isClockifyEnabled()) {
+    return c.json({ ok: false, error: 'Calendar sync requires Clockify.' }, 400);
+  }
   const { entries } = await c.req.json<{
     entries: Array<{ summary: string; start: string; end: string; projectId: string; billable?: boolean }>;
   }>();

--- a/dashboard/routes/clockify.ts
+++ b/dashboard/routes/clockify.ts
@@ -1,8 +1,14 @@
 import { Hono } from 'hono';
 import axios from 'axios';
-import { saveCredential } from '../../lib/credentials.js';
+import { saveCredential, setClockifyDisabled } from '../../lib/credentials.js';
 
 const clockifyRoutes = new Hono();
+
+clockifyRoutes.post('/clockify/enabled', async (c) => {
+  const { enabled } = await c.req.json<{ enabled: boolean }>();
+  setClockifyDisabled(!enabled);
+  return c.json({ ok: true });
+});
 
 clockifyRoutes.post('/clockify', async (c) => {
   const { apiKey } = await c.req.json<{ apiKey: string }>();

--- a/dashboard/routes/data.ts
+++ b/dashboard/routes/data.ts
@@ -6,7 +6,6 @@ import {
   getAllProjects,
   upsertProjects,
   toggleProjectActive,
-  getLastDescriptionByJiraTicket,
 } from '../../lib/db.js';
 import { Clockify } from '../../clockify.js';
 import { isClockifyEnabled } from '../../lib/credentials.js';
@@ -79,18 +78,16 @@ dataRoutes.get('/sessions', (c) => {
   });
 });
 
-// Lookup description for a Jira ticket: last saved from DB, fall back to Jira summary
-dataRoutes.get('/sessions/last-description', async (c) => {
+// Current Jira ticket summary for timer description preview
+dataRoutes.get('/jira/ticket-summary', async (c) => {
   const ticket = (c.req.query('jira') || '').trim().toUpperCase();
   if (!ticket || !/^[A-Z][A-Z0-9]+-\d+$/.test(ticket)) {
     return c.json({ ok: false, error: 'Invalid ticket.' }, 400);
   }
-  const fromDb = getLastDescriptionByJiraTicket(ticket);
-  if (fromDb) return c.json({ ok: true, description: fromDb, source: 'db' });
   try {
     const issue = (await getJiraTicket(ticket)) as { fields?: { summary?: string } } | null;
     const summary = issue?.fields?.summary?.trim();
-    if (summary) return c.json({ ok: true, description: summary, source: 'jira' });
+    if (summary) return c.json({ ok: true, description: summary });
   } catch (err) {
     console.warn('Jira summary lookup failed for', ticket, err);
   }

--- a/dashboard/routes/data.ts
+++ b/dashboard/routes/data.ts
@@ -8,7 +8,7 @@ import {
   toggleProjectActive,
 } from '../../lib/db.js';
 import { Clockify } from '../../clockify.js';
-import { isClockifyEnabled } from '../../lib/credentials.js';
+import { isClockifyEnabled, isJiraDisabled } from '../../lib/credentials.js';
 import { getJiraTicket } from '../../lib/jira.js';
 
 const dataRoutes = new Hono();
@@ -84,6 +84,7 @@ dataRoutes.get('/jira/ticket-summary', async (c) => {
   if (!ticket || !/^[A-Z][A-Z0-9]+-\d+$/.test(ticket)) {
     return c.json({ ok: false, error: 'Invalid ticket.' }, 400);
   }
+  if (isJiraDisabled()) return c.json({ ok: true, description: null });
   try {
     const issue = (await getJiraTicket(ticket)) as { fields?: { summary?: string } } | null;
     const summary = issue?.fields?.summary?.trim();

--- a/dashboard/routes/data.ts
+++ b/dashboard/routes/data.ts
@@ -8,6 +8,7 @@ import {
   toggleProjectActive,
 } from '../../lib/db.js';
 import { Clockify } from '../../clockify.js';
+import { isClockifyEnabled } from '../../lib/credentials.js';
 
 const dataRoutes = new Hono();
 
@@ -25,6 +26,9 @@ dataRoutes.get('/projects/all', (c) => {
 
 // Fetch projects from Clockify and save to DB
 dataRoutes.post('/projects/fetch', async (c) => {
+  if (!isClockifyEnabled()) {
+    return c.json({ ok: false, error: 'Clockify not configured.' }, 400);
+  }
   try {
     const clockify = new Clockify();
     const user = await clockify.getUser();

--- a/dashboard/routes/data.ts
+++ b/dashboard/routes/data.ts
@@ -6,6 +6,7 @@ import {
   getAllProjects,
   upsertProjects,
   toggleProjectActive,
+  getLastDescriptionByJiraTicket,
 } from '../../lib/db.js';
 import { Clockify } from '../../clockify.js';
 import { isClockifyEnabled } from '../../lib/credentials.js';
@@ -75,6 +76,16 @@ dataRoutes.get('/sessions', (c) => {
     total,
     totalPages: Math.ceil(total / limit),
   });
+});
+
+// Lookup last saved description for a Jira ticket (Jira-only preview)
+dataRoutes.get('/sessions/last-description', (c) => {
+  const ticket = (c.req.query('jira') || '').trim();
+  if (!ticket || !/^[A-Z][A-Z0-9]+-\d+$/.test(ticket)) {
+    return c.json({ ok: false, error: 'Invalid ticket.' }, 400);
+  }
+  const description = getLastDescriptionByJiraTicket(ticket);
+  return c.json({ ok: true, description });
 });
 
 export default dataRoutes;

--- a/dashboard/routes/data.ts
+++ b/dashboard/routes/data.ts
@@ -10,6 +10,7 @@ import {
 } from '../../lib/db.js';
 import { Clockify } from '../../clockify.js';
 import { isClockifyEnabled } from '../../lib/credentials.js';
+import { getJiraTicket } from '../../lib/jira.js';
 
 const dataRoutes = new Hono();
 
@@ -78,14 +79,22 @@ dataRoutes.get('/sessions', (c) => {
   });
 });
 
-// Lookup last saved description for a Jira ticket (Jira-only preview)
-dataRoutes.get('/sessions/last-description', (c) => {
-  const ticket = (c.req.query('jira') || '').trim();
+// Lookup description for a Jira ticket: last saved from DB, fall back to Jira summary
+dataRoutes.get('/sessions/last-description', async (c) => {
+  const ticket = (c.req.query('jira') || '').trim().toUpperCase();
   if (!ticket || !/^[A-Z][A-Z0-9]+-\d+$/.test(ticket)) {
     return c.json({ ok: false, error: 'Invalid ticket.' }, 400);
   }
-  const description = getLastDescriptionByJiraTicket(ticket);
-  return c.json({ ok: true, description });
+  const fromDb = getLastDescriptionByJiraTicket(ticket);
+  if (fromDb) return c.json({ ok: true, description: fromDb, source: 'db' });
+  try {
+    const issue = (await getJiraTicket(ticket)) as { fields?: { summary?: string } } | null;
+    const summary = issue?.fields?.summary?.trim();
+    if (summary) return c.json({ ok: true, description: summary, source: 'jira' });
+  } catch (err) {
+    console.warn('Jira summary lookup failed for', ticket, err);
+  }
+  return c.json({ ok: true, description: null });
 });
 
 export default dataRoutes;

--- a/dashboard/routes/data.ts
+++ b/dashboard/routes/data.ts
@@ -65,7 +65,7 @@ dataRoutes.get('/sessions', (c) => {
 
   const enriched = (sessions as Array<Record<string, unknown>>).map((s) => ({
     ...s,
-    projectName: projectMap.get(s.projectId as string) ?? 'Unknown',
+    projectName: s.projectId ? (projectMap.get(s.projectId as string) ?? 'Unknown') : null,
   }));
 
   return c.json({

--- a/dashboard/routes/jira.ts
+++ b/dashboard/routes/jira.ts
@@ -1,10 +1,16 @@
 import { Hono } from 'hono';
 import axios from 'axios';
-import { saveCredential } from '../../lib/credentials.js';
+import { saveCredential, setJiraDisabled } from '../../lib/credentials.js';
 import { storeAtlassianToken } from '../../lib/db.js';
 import { getAtlassianAuthUrl, exchangeCodeForTokens, getAccessibleResources } from '../../lib/atlassian.js';
 
 const jiraRoutes = new Hono();
+
+jiraRoutes.post('/jira/enabled', async (c) => {
+  const { enabled } = await c.req.json<{ enabled: boolean }>();
+  setJiraDisabled(!enabled);
+  return c.json({ ok: true });
+});
 
 // OAuth: redirect to Atlassian authorization (browser fallback)
 jiraRoutes.get('/jira/connect', async (c) => {

--- a/dashboard/routes/status.ts
+++ b/dashboard/routes/status.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import axios from 'axios';
-import { resolveCredential } from '../../lib/credentials.js';
+import { isClockifyDisabled, resolveCredential } from '../../lib/credentials.js';
 import { getLatestToken, getAtlassianToken } from '../../lib/db.js';
 import { getValidAccessToken } from '../../lib/atlassian.js';
 
@@ -9,6 +9,7 @@ const statusRoutes = new Hono();
 statusRoutes.get('/status', async (c) => {
   const results: {
     clockify: boolean;
+    clockifyDisabled: boolean;
     google: boolean;
     googleEmail?: string;
     jira: boolean;
@@ -17,6 +18,7 @@ statusRoutes.get('/status', async (c) => {
     clockifyKeyHint?: string;
   } = {
     clockify: false,
+    clockifyDisabled: isClockifyDisabled(),
     google: false,
     jira: false,
     jiraOAuth: false,
@@ -26,13 +28,15 @@ statusRoutes.get('/status', async (c) => {
   const clockifyKey = resolveCredential('CLOCKIFY_API_KEY');
   if (clockifyKey) {
     results.clockifyKeyHint = '***' + clockifyKey.slice(-4);
-    try {
-      const res = await axios.get('https://api.clockify.me/api/v1/user', {
-        headers: { 'X-Api-Key': clockifyKey },
-        timeout: 5000,
-      });
-      results.clockify = res.status === 200;
-    } catch {}
+    if (!results.clockifyDisabled) {
+      try {
+        const res = await axios.get('https://api.clockify.me/api/v1/user', {
+          headers: { 'X-Api-Key': clockifyKey },
+          timeout: 5000,
+        });
+        results.clockify = res.status === 200;
+      } catch {}
+    }
   }
 
   // Check Google — token exists in DB

--- a/dashboard/routes/status.ts
+++ b/dashboard/routes/status.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import axios from 'axios';
-import { isClockifyDisabled, resolveCredential } from '../../lib/credentials.js';
+import { isClockifyDisabled, isJiraDisabled, resolveCredential } from '../../lib/credentials.js';
 import { getLatestToken, getAtlassianToken } from '../../lib/db.js';
 import { getValidAccessToken } from '../../lib/atlassian.js';
 
@@ -13,6 +13,8 @@ statusRoutes.get('/status', async (c) => {
     google: boolean;
     googleEmail?: string;
     jira: boolean;
+    jiraDisabled: boolean;
+    jiraConfigured: boolean;
     jiraOAuth: boolean;
     jiraSiteUrl?: string;
     clockifyKeyHint?: string;
@@ -21,6 +23,8 @@ statusRoutes.get('/status', async (c) => {
     clockifyDisabled: isClockifyDisabled(),
     google: false,
     jira: false,
+    jiraDisabled: isJiraDisabled(),
+    jiraConfigured: false,
     jiraOAuth: false,
   };
 
@@ -51,42 +55,48 @@ statusRoutes.get('/status', async (c) => {
   const storedAtlassianToken = getAtlassianToken();
   if (storedAtlassianToken) {
     results.jiraOAuth = true;
+    results.jiraConfigured = true;
     if (storedAtlassianToken.site_url) results.jiraSiteUrl = storedAtlassianToken.site_url;
-    try {
-      const validToken = await getValidAccessToken();
-      if (validToken) {
-        const res = await axios.get(`https://api.atlassian.com/ex/jira/${validToken.cloud_id}/rest/api/3/myself`, {
-          headers: {
-            Authorization: `Bearer ${validToken.access_token}`,
-            Accept: 'application/json',
-          },
-          timeout: 5000,
-        });
-        results.jira = res.status === 200;
+    if (!results.jiraDisabled) {
+      try {
+        const validToken = await getValidAccessToken();
+        if (validToken) {
+          const res = await axios.get(`https://api.atlassian.com/ex/jira/${validToken.cloud_id}/rest/api/3/myself`, {
+            headers: {
+              Authorization: `Bearer ${validToken.access_token}`,
+              Accept: 'application/json',
+            },
+            timeout: 5000,
+          });
+          results.jira = res.status === 200;
+        }
+      } catch (error) {
+        if (axios.isAxiosError(error)) {
+          console.error('Jira OAuth status check failed:', error.response?.status, error.response?.data);
+        } else {
+          console.error('Jira OAuth status check failed:', error);
+        }
+        results.jira = false;
       }
-    } catch (error) {
-      if (axios.isAxiosError(error)) {
-        console.error('Jira OAuth status check failed:', error.response?.status, error.response?.data);
-      } else {
-        console.error('Jira OAuth status check failed:', error);
-      }
-      results.jira = false;
     }
   } else {
     const jiraUrl = resolveCredential('ATLASSIAN_URL');
     const jiraToken = resolveCredential('ATLASSIAN_API_TOKEN');
     const jiraEmail = resolveCredential('ATLASSIAN_EMAIL');
     if (jiraUrl && jiraToken && jiraEmail) {
-      try {
-        const res = await axios.get(`${jiraUrl}/myself`, {
-          headers: {
-            Authorization: `Basic ${Buffer.from(`${jiraEmail}:${jiraToken}`).toString('base64')}`,
-            Accept: 'application/json',
-          },
-          timeout: 5000,
-        });
-        results.jira = res.status === 200;
-      } catch {}
+      results.jiraConfigured = true;
+      if (!results.jiraDisabled) {
+        try {
+          const res = await axios.get(`${jiraUrl}/myself`, {
+            headers: {
+              Authorization: `Basic ${Buffer.from(`${jiraEmail}:${jiraToken}`).toString('base64')}`,
+              Accept: 'application/json',
+            },
+            timeout: 5000,
+          });
+          results.jira = res.status === 200;
+        } catch {}
+      }
     }
   }
 

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -97,26 +97,30 @@ timerRoutes.post('/timer/start', async (c) => {
     if (!projectId || !cleanDescription) {
       return c.json({ ok: false, error: 'Project and description are required.' }, 400);
     }
+    let clockifyStarted = false;
     try {
       const clockify = new Clockify();
       const user = await clockify.getUser();
-      if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
-
-      const result = await clockify.startTimer(
-        user.defaultWorkspace,
-        projectId,
-        cleanDescription,
-        cleanJira,
-        billable ?? true,
-      );
-      if (!result) return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
-      return c.json({ ok: true });
-    } catch {
-      return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
+      if (user) {
+        const result = await clockify.startTimer(
+          user.defaultWorkspace,
+          projectId,
+          cleanDescription,
+          cleanJira,
+          billable ?? true,
+        );
+        if (result) clockifyStarted = true;
+        else console.warn('Clockify startTimer returned null; falling through to Jira-only path.');
+      } else {
+        console.warn('Clockify enabled but getUser failed; falling through to Jira-only path.');
+      }
+    } catch (err) {
+      console.warn('Clockify start threw; falling through to Jira-only path:', err);
     }
+    if (clockifyStarted) return c.json({ ok: true });
   }
 
-  // Jira-only mode
+  // Jira-only path (also used as fallback when Clockify is unreachable)
   if (!cleanJira) {
     return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
   }
@@ -137,11 +141,19 @@ timerRoutes.post('/timer/stop', async (c) => {
     const openSession = getOpenSession();
 
     if (isClockifyEnabled()) {
-      const clockify = new Clockify();
-      const user = await clockify.getUser();
-      if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
-      const result = await clockify.stopTimer(user.defaultWorkspace, user.id);
-      if (!result) return c.json({ ok: false, error: 'Failed to stop timer.' }, 500);
+      try {
+        const clockify = new Clockify();
+        const user = await clockify.getUser();
+        if (user) {
+          const result = await clockify.stopTimer(user.defaultWorkspace, user.id);
+          if (!result) console.warn('Clockify stopTimer returned null; proceeding with DB + worklog.');
+        } else {
+          console.warn('Clockify enabled but getUser failed; proceeding with DB + worklog.');
+        }
+      } catch (err) {
+        console.warn('Clockify stop threw; proceeding with DB + worklog:', err);
+      }
+      if (!openSession) return c.json({ ok: false, error: 'No active timer.' }, 404);
     } else if (!openSession) {
       return c.json({ ok: false, error: 'No active timer.' }, 404);
     }
@@ -212,25 +224,36 @@ timerRoutes.post('/timer/log', async (c) => {
   const startIso = new Date(startMs).toISOString();
   const endIso = new Date(endMs).toISOString();
   const finalDescription = cleanDescription || cleanJira!;
-  let entryId: string;
+  let entryId: string | undefined;
 
   try {
     if (clockifyOn) {
-      const clockify = new Clockify();
-      const user = await clockify.getUser();
-      if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
+      try {
+        const clockify = new Clockify();
+        const user = await clockify.getUser();
+        if (user) {
+          const entry = await clockify.logTime(
+            user.defaultWorkspace,
+            projectId!,
+            startIso,
+            endIso,
+            finalDescription,
+            billable ?? true,
+          );
+          if (entry) entryId = (entry as { id?: string }).id ?? uuidv4();
+          else console.warn('Clockify logTime returned null; falling through to Jira-only path.');
+        } else {
+          console.warn('Clockify enabled but getUser failed; falling through to Jira-only path.');
+        }
+      } catch (err) {
+        console.warn('Clockify log threw; falling through to Jira-only path:', err);
+      }
+    }
 
-      const entry = await clockify.logTime(
-        user.defaultWorkspace,
-        projectId!,
-        startIso,
-        endIso,
-        finalDescription,
-        billable ?? true,
-      );
-      if (!entry) return c.json({ ok: false, error: 'Failed to log time in Clockify.' }, 500);
-      entryId = (entry as { id?: string }).id ?? uuidv4();
-    } else {
+    if (!entryId) {
+      if (!cleanJira) {
+        return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
+      }
       entryId = uuidv4();
     }
 

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -263,13 +263,16 @@ timerRoutes.delete('/timer/:id', async (c) => {
   if (!session) return c.json({ ok: false, error: 'Session not found.' }, 404);
 
   try {
-    const clockify = new Clockify();
-    const user = await clockify.getUser();
-    if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
-
-    const clockifyOk = await clockify.deleteTimeEntry(user.defaultWorkspace, id);
-    // Continue even if Clockify delete fails — the entry may already be gone remotely.
-    if (!clockifyOk) console.warn(`Clockify delete returned failure for ${id}; removing local record anyway.`);
+    if (isClockifyEnabled()) {
+      const clockify = new Clockify();
+      const user = await clockify.getUser();
+      if (user) {
+        const clockifyOk = await clockify.deleteTimeEntry(user.defaultWorkspace, id);
+        if (!clockifyOk) console.warn(`Clockify delete returned failure for ${id}; removing local record anyway.`);
+      } else {
+        console.warn('Clockify enabled but getUser failed; skipping remote delete.');
+      }
+    }
 
     if (session.jiraTicket && session.jiraWorklogId) {
       try {

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -132,18 +132,18 @@ timerRoutes.post('/timer/start', async (c) => {
     if (clockifyStarted) return c.json({ ok: true });
   }
 
-  // Jira-only path (also used as fallback when Clockify is unreachable)
-  if (!cleanJira) {
-    return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
+  // Jira-only or local-only path (also used as fallback when Clockify is unreachable)
+  if (!cleanJira && !cleanDescription) {
+    return c.json({ ok: false, error: 'Description or Jira ticket is required.' }, 400);
   }
-  const finalDescription = await buildJiraDescription(cleanJira, cleanDescription);
+  const finalDescription = cleanJira ? await buildJiraDescription(cleanJira, cleanDescription) : cleanDescription;
   const sessionId = uuidv4();
   const startedAt = new Date().toISOString();
   try {
     logSessionStart(sessionId, projectId ?? null, finalDescription, startedAt, cleanJira);
     return c.json({ ok: true });
   } catch (err) {
-    console.error('Error starting Jira-only session:', err);
+    console.error('Error starting session:', err);
     return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
   }
 });
@@ -220,17 +220,11 @@ timerRoutes.post('/timer/log', async (c) => {
   const cleanJira = jiraTicket?.trim() || undefined;
   const clockifyOn = isClockifyEnabled();
 
-  if (clockifyOn) {
-    if (!projectId) {
-      return c.json({ ok: false, error: 'Project is required.' }, 400);
-    }
-    if (!cleanDescription && !cleanJira) {
-      return c.json({ ok: false, error: 'Description or Jira ticket is required.' }, 400);
-    }
-  } else {
-    if (!cleanJira) {
-      return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
-    }
+  if (clockifyOn && !projectId) {
+    return c.json({ ok: false, error: 'Project is required.' }, 400);
+  }
+  if (!cleanDescription && !cleanJira) {
+    return c.json({ ok: false, error: 'Description or Jira ticket is required.' }, 400);
   }
 
   const startIso = new Date(startMs).toISOString();
@@ -268,15 +262,14 @@ timerRoutes.post('/timer/log', async (c) => {
     }
 
     if (!entryId) {
-      if (!cleanJira) {
-        return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
-      }
       entryId = uuidv4();
     }
 
     const finalDescription = clockifySucceeded
       ? clockifyDescription
-      : await buildJiraDescription(cleanJira!, cleanDescription);
+      : cleanJira
+        ? await buildJiraDescription(cleanJira, cleanDescription)
+        : cleanDescription;
 
     logCompletedSession(entryId, projectId ?? null, finalDescription, startIso, endIso, cleanJira);
 

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -10,12 +10,24 @@ import {
   logSessionStart,
   setSessionJiraWorklogId,
 } from '../../lib/db.js';
-import { deleteJiraWorklog, stopJiraTimer } from '../../lib/jira.js';
+import { deleteJiraWorklog, getJiraTicket, stopJiraTimer } from '../../lib/jira.js';
 import { isClockifyEnabled } from '../../lib/credentials.js';
 
 function extractJiraTicket(description: string): string | undefined {
   const match = description.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
   return match?.[1];
+}
+
+async function buildJiraDescription(ticket: string, typed: string): Promise<string> {
+  if (typed && typed !== ticket) return typed;
+  try {
+    const issue = (await getJiraTicket(ticket)) as { fields?: { summary?: string } } | null;
+    const summary = issue?.fields?.summary?.trim();
+    if (summary) return ticket + ' ' + summary;
+  } catch (err) {
+    console.warn('Jira summary lookup failed for', ticket, err);
+  }
+  return ticket;
 }
 
 const timerRoutes = new Hono();
@@ -124,7 +136,7 @@ timerRoutes.post('/timer/start', async (c) => {
   if (!cleanJira) {
     return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
   }
-  const finalDescription = cleanDescription || cleanJira;
+  const finalDescription = await buildJiraDescription(cleanJira, cleanDescription);
   const sessionId = uuidv4();
   const startedAt = new Date().toISOString();
   try {
@@ -223,8 +235,9 @@ timerRoutes.post('/timer/log', async (c) => {
 
   const startIso = new Date(startMs).toISOString();
   const endIso = new Date(endMs).toISOString();
-  const finalDescription = cleanDescription || cleanJira!;
+  const clockifyDescription = cleanDescription || cleanJira || '';
   let entryId: string | undefined;
+  let clockifySucceeded = false;
 
   try {
     if (clockifyOn) {
@@ -237,11 +250,15 @@ timerRoutes.post('/timer/log', async (c) => {
             projectId!,
             startIso,
             endIso,
-            finalDescription,
+            clockifyDescription,
             billable ?? true,
           );
-          if (entry) entryId = (entry as { id?: string }).id ?? uuidv4();
-          else console.warn('Clockify logTime returned null; falling through to Jira-only path.');
+          if (entry) {
+            entryId = (entry as { id?: string }).id ?? uuidv4();
+            clockifySucceeded = true;
+          } else {
+            console.warn('Clockify logTime returned null; falling through to Jira-only path.');
+          }
         } else {
           console.warn('Clockify enabled but getUser failed; falling through to Jira-only path.');
         }
@@ -256,6 +273,10 @@ timerRoutes.post('/timer/log', async (c) => {
       }
       entryId = uuidv4();
     }
+
+    const finalDescription = clockifySucceeded
+      ? clockifyDescription
+      : await buildJiraDescription(cleanJira!, cleanDescription);
 
     logCompletedSession(entryId, projectId ?? null, finalDescription, startIso, endIso, cleanJira);
 

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -21,6 +21,18 @@ function extractJiraTicket(description: string): string | undefined {
 const timerRoutes = new Hono();
 
 timerRoutes.get('/timer/active', async (c) => {
+  if (!isClockifyEnabled()) {
+    const openSession = getOpenSession();
+    if (!openSession) return c.json({ active: false });
+    return c.json({
+      active: true,
+      description: openSession.description,
+      projectId: openSession.projectId,
+      start: openSession.startedAt,
+      ...(openSession.jiraTicket ? { jiraTicket: openSession.jiraTicket } : {}),
+    });
+  }
+
   try {
     const clockify = new Clockify();
     const user = await clockify.getUser();
@@ -28,7 +40,6 @@ timerRoutes.get('/timer/active', async (c) => {
 
     const timer = await clockify.getActiveTimer(user.defaultWorkspace, user.id);
     if (!timer) {
-      // Timer stopped externally (e.g. in Clockify app) — close any lingering open session
       const openSession = getOpenSession();
       if (openSession) {
         const completedAt = new Date().toISOString();
@@ -50,7 +61,6 @@ timerRoutes.get('/timer/active', async (c) => {
       return c.json({ active: false });
     }
 
-    // Sync externally-started timers (e.g. from Clockify app or Jira plugin) to DB
     const timerStart = timer.timeInterval.start as string;
     const jiraTicket = extractJiraTicket(timer.description ?? '');
     const openSession = getOpenSession();

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -134,13 +134,17 @@ timerRoutes.post('/timer/start', async (c) => {
 
 timerRoutes.post('/timer/stop', async (c) => {
   try {
-    const clockify = new Clockify();
-    const user = await clockify.getUser();
-    if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
-
     const openSession = getOpenSession();
-    const result = await clockify.stopTimer(user.defaultWorkspace, user.id);
-    if (!result) return c.json({ ok: false, error: 'Failed to stop timer.' }, 500);
+
+    if (isClockifyEnabled()) {
+      const clockify = new Clockify();
+      const user = await clockify.getUser();
+      if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
+      const result = await clockify.stopTimer(user.defaultWorkspace, user.id);
+      if (!result) return c.json({ ok: false, error: 'Failed to stop timer.' }, 500);
+    } else if (!openSession) {
+      return c.json({ ok: false, error: 'No active timer.' }, 404);
+    }
 
     const completedAt = new Date().toISOString();
     completeLatestSession(completedAt, false);

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -11,7 +11,7 @@ import {
   setSessionJiraWorklogId,
 } from '../../lib/db.js';
 import { deleteJiraWorklog, getJiraTicket, stopJiraTimer } from '../../lib/jira.js';
-import { isClockifyEnabled } from '../../lib/credentials.js';
+import { isClockifyEnabled, isJiraDisabled } from '../../lib/credentials.js';
 
 function extractJiraTicket(description: string): string | undefined {
   const match = description.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
@@ -20,6 +20,7 @@ function extractJiraTicket(description: string): string | undefined {
 
 async function buildJiraDescription(ticket: string, typed: string): Promise<string> {
   if (typed && typed !== ticket) return typed;
+  if (isJiraDisabled()) return ticket;
   try {
     const issue = (await getJiraTicket(ticket)) as { fields?: { summary?: string } } | null;
     const summary = issue?.fields?.summary?.trim();
@@ -56,7 +57,7 @@ timerRoutes.get('/timer/active', async (c) => {
       if (openSession) {
         const completedAt = new Date().toISOString();
         completeLatestSession(completedAt, false);
-        if (openSession.jiraTicket) {
+        if (openSession.jiraTicket && !isJiraDisabled()) {
           const timeSpentSeconds = Math.round(
             (new Date(completedAt).getTime() - new Date(openSession.startedAt).getTime()) / 1000,
           );
@@ -173,7 +174,7 @@ timerRoutes.post('/timer/stop', async (c) => {
     const completedAt = new Date().toISOString();
     completeLatestSession(completedAt, false);
 
-    if (openSession?.jiraTicket) {
+    if (openSession?.jiraTicket && !isJiraDisabled()) {
       const timeSpentSeconds = Math.round(
         (new Date(completedAt).getTime() - new Date(openSession.startedAt).getTime()) / 1000,
       );
@@ -273,7 +274,7 @@ timerRoutes.post('/timer/log', async (c) => {
 
     logCompletedSession(entryId, projectId ?? null, finalDescription, startIso, endIso, cleanJira);
 
-    if (cleanJira) {
+    if (cleanJira && !isJiraDisabled()) {
       const timeSpentSeconds = Math.round((endMs - startMs) / 1000);
       if (timeSpentSeconds >= 60) {
         try {
@@ -311,7 +312,7 @@ timerRoutes.delete('/timer/:id', async (c) => {
       }
     }
 
-    if (session.jiraTicket && session.jiraWorklogId) {
+    if (session.jiraTicket && session.jiraWorklogId && !isJiraDisabled()) {
       try {
         await deleteJiraWorklog(session.jiraTicket, session.jiraWorklogId);
       } catch (err) {

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -21,19 +21,19 @@ function extractJiraTicket(description: string): string | undefined {
 const timerRoutes = new Hono();
 
 timerRoutes.get('/timer/active', async (c) => {
-  if (!isClockifyEnabled()) {
-    const openSession = getOpenSession();
-    if (!openSession) return c.json({ active: false });
-    return c.json({
-      active: true,
-      description: openSession.description,
-      projectId: openSession.projectId,
-      start: openSession.startedAt,
-      ...(openSession.jiraTicket ? { jiraTicket: openSession.jiraTicket } : {}),
-    });
-  }
-
   try {
+    if (!isClockifyEnabled()) {
+      const openSession = getOpenSession();
+      if (!openSession) return c.json({ active: false });
+      return c.json({
+        active: true,
+        description: openSession.description,
+        projectId: openSession.projectId,
+        start: openSession.startedAt,
+        ...(openSession.jiraTicket ? { jiraTicket: openSession.jiraTicket } : {}),
+      });
+    }
+
     const clockify = new Clockify();
     const user = await clockify.getUser();
     if (!user) return c.json({ active: false });

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -171,7 +171,7 @@ timerRoutes.post('/timer/stop', async (c) => {
 
 timerRoutes.post('/timer/log', async (c) => {
   const { projectId, description, start, end, jiraTicket, billable } = await c.req.json<{
-    projectId: string;
+    projectId?: string | null;
     description: string;
     start: string;
     end: string;
@@ -179,9 +179,6 @@ timerRoutes.post('/timer/log', async (c) => {
     billable?: boolean;
   }>();
 
-  if (!projectId) {
-    return c.json({ ok: false, error: 'Project is required.' }, 400);
-  }
   if (!start || !end) {
     return c.json({ ok: false, error: 'Start and end are required.' }, 400);
   }
@@ -197,31 +194,47 @@ timerRoutes.post('/timer/log', async (c) => {
 
   const cleanDescription = (description ?? '').trim();
   const cleanJira = jiraTicket?.trim() || undefined;
-  if (!cleanDescription && !cleanJira) {
-    return c.json({ ok: false, error: 'Description or Jira ticket is required.' }, 400);
+  const clockifyOn = isClockifyEnabled();
+
+  if (clockifyOn) {
+    if (!projectId) {
+      return c.json({ ok: false, error: 'Project is required.' }, 400);
+    }
+    if (!cleanDescription && !cleanJira) {
+      return c.json({ ok: false, error: 'Description or Jira ticket is required.' }, 400);
+    }
+  } else {
+    if (!cleanJira) {
+      return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
+    }
   }
 
+  const startIso = new Date(startMs).toISOString();
+  const endIso = new Date(endMs).toISOString();
+  const finalDescription = cleanDescription || cleanJira!;
+  let entryId: string;
+
   try {
-    const clockify = new Clockify();
-    const user = await clockify.getUser();
-    if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
+    if (clockifyOn) {
+      const clockify = new Clockify();
+      const user = await clockify.getUser();
+      if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
 
-    const startIso = new Date(startMs).toISOString();
-    const endIso = new Date(endMs).toISOString();
-    const finalDescription = cleanDescription || cleanJira!;
+      const entry = await clockify.logTime(
+        user.defaultWorkspace,
+        projectId!,
+        startIso,
+        endIso,
+        finalDescription,
+        billable ?? true,
+      );
+      if (!entry) return c.json({ ok: false, error: 'Failed to log time in Clockify.' }, 500);
+      entryId = (entry as { id?: string }).id ?? uuidv4();
+    } else {
+      entryId = uuidv4();
+    }
 
-    const entry = await clockify.logTime(
-      user.defaultWorkspace,
-      projectId,
-      startIso,
-      endIso,
-      finalDescription,
-      billable ?? true,
-    );
-    if (!entry) return c.json({ ok: false, error: 'Failed to log time in Clockify.' }, 500);
-
-    const entryId = (entry as { id?: string }).id ?? uuidv4();
-    logCompletedSession(entryId, projectId, finalDescription, startIso, endIso, cleanJira);
+    logCompletedSession(entryId, projectId ?? null, finalDescription, startIso, endIso, cleanJira);
 
     if (cleanJira) {
       const timeSpentSeconds = Math.round((endMs - startMs) / 1000);

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -11,6 +11,7 @@ import {
   setSessionJiraWorklogId,
 } from '../../lib/db.js';
 import { deleteJiraWorklog, stopJiraTimer } from '../../lib/jira.js';
+import { isClockifyEnabled } from '../../lib/credentials.js';
 
 function extractJiraTicket(description: string): string | undefined {
   const match = description.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
@@ -72,34 +73,48 @@ timerRoutes.get('/timer/active', async (c) => {
 
 timerRoutes.post('/timer/start', async (c) => {
   const { projectId, description, jiraTicket, billable } = await c.req.json<{
-    projectId: string;
+    projectId?: string | null;
     description: string;
     jiraTicket?: string;
     billable?: boolean;
   }>();
 
-  if (!projectId || !description) {
-    return c.json({ ok: false, error: 'Project and description are required.' }, 400);
+  const cleanDescription = (description ?? '').trim();
+  const cleanJira = jiraTicket?.trim() || undefined;
+  const clockifyOn = isClockifyEnabled();
+
+  if (clockifyOn) {
+    if (!projectId || !cleanDescription) {
+      return c.json({ ok: false, error: 'Project and description are required.' }, 400);
+    }
+    try {
+      const clockify = new Clockify();
+      const user = await clockify.getUser();
+      if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
+
+      const result = await clockify.startTimer(
+        user.defaultWorkspace,
+        projectId,
+        cleanDescription,
+        cleanJira,
+        billable ?? true,
+      );
+      if (!result) return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
+      return c.json({ ok: true });
+    } catch {
+      return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
+    }
   }
 
-  try {
-    const clockify = new Clockify();
-    const user = await clockify.getUser();
-    if (!user) return c.json({ ok: false, error: 'Could not connect to Clockify.' }, 500);
-
-    const result = await clockify.startTimer(
-      user.defaultWorkspace,
-      projectId,
-      description,
-      jiraTicket,
-      billable ?? true,
-    );
-    if (!result) return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
-
-    return c.json({ ok: true });
-  } catch {
-    return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
+  // Jira-only mode
+  if (!cleanJira) {
+    return c.json({ ok: false, error: 'Jira ticket required in Jira-only mode.' }, 400);
   }
+  const finalDescription = cleanDescription || cleanJira;
+  const sessionId = uuidv4();
+  const startedAt = new Date().toISOString();
+  logSessionStart(sessionId, projectId ?? null, finalDescription, startedAt, cleanJira);
+  return c.json({ ok: true });
 });
 
 timerRoutes.post('/timer/stop', async (c) => {

--- a/dashboard/routes/timer.ts
+++ b/dashboard/routes/timer.ts
@@ -113,8 +113,13 @@ timerRoutes.post('/timer/start', async (c) => {
   const finalDescription = cleanDescription || cleanJira;
   const sessionId = uuidv4();
   const startedAt = new Date().toISOString();
-  logSessionStart(sessionId, projectId ?? null, finalDescription, startedAt, cleanJira);
-  return c.json({ ok: true });
+  try {
+    logSessionStart(sessionId, projectId ?? null, finalDescription, startedAt, cleanJira);
+    return c.json({ ok: true });
+  } catch (err) {
+    console.error('Error starting Jira-only session:', err);
+    return c.json({ ok: false, error: 'Failed to start timer.' }, 500);
+  }
 });
 
 timerRoutes.post('/timer/stop', async (c) => {

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -1331,9 +1331,13 @@ export function indexPage() {
         }
         const toggle = document.getElementById('clockify-enabled-toggle');
         const toggleLabel = document.getElementById('clockify-enabled-label');
+        const keyInput = document.getElementById('clockify-key');
+        const saveBtn = document.querySelector('button[onclick="saveClockify()"]');
         const enabled = !data.clockifyDisabled;
         if (toggle) toggle.checked = enabled;
         if (toggleLabel) toggleLabel.textContent = enabled ? 'Enabled' : 'Disabled';
+        if (keyInput) keyInput.disabled = !enabled;
+        if (saveBtn) saveBtn.disabled = !enabled;
         setGoogleConnected(data.google, data.googleEmail);
         setJiraConnected(data.jira, data.jiraOAuth, data.jiraSiteUrl);
         applyMode(data);

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -125,11 +125,16 @@ export function indexPage() {
     .toggle input:checked + .slider { background: #238636; }
     .toggle input:checked + .slider::before { transform: translateX(16px); background: #fff; }
 
+    .is-disabled { opacity: 0.45; pointer-events: none; }
+    .mode-chip { display: inline-block; padding: 0.15rem 0.5rem; margin-left: 0.5rem; border-radius: 999px; font-size: 0.75rem; background: #1f6feb22; color: #58a6ff; }
+    .mode-pill { display: inline-block; padding: 0.15rem 0.6rem; margin-left: 0.5rem; border-radius: 999px; font-size: 0.7rem; background: #1f6feb22; color: #58a6ff; vertical-align: middle; }
+    .empty-state-card { padding: 1.5rem; text-align: center; color: #8b949e; font-size: 0.9rem; }
+
   </style>
 </head>
 <body oncontextmenu="return false;">
   <div class="header">
-    <h1>Clocktopus</h1>
+    <h1>Clocktopus<span id="mode-pill" class="mode-pill" style="display:none;">Jira-only</span></h1>
     <div class="nav">
       <button class="nav-btn active" onclick="switchTab('home')" id="nav-home">Home</button>
       <button class="nav-btn" onclick="switchTab('projects')" id="nav-projects">Projects</button>
@@ -152,18 +157,21 @@ export function indexPage() {
 
     <div class="cards home-cards">
       <!-- Track Time -->
-      <div class="card">
-        <div class="track-tabs">
+      <div class="card" id="track-card">
+        <div class="track-tabs" id="track-tabs">
           <button class="track-tab-btn active" data-mode="auto" onclick="switchTrackMode('auto')">Auto Track</button>
           <button class="track-tab-btn" data-mode="manual" onclick="switchTrackMode('manual')">Manual Log</button>
+          <span id="track-mode-chip" class="mode-chip" style="display:none;">Jira-only mode</span>
         </div>
 
         <div id="track-auto">
           <div id="start-timer-form">
-            <label for="project-select">Project</label>
-            <select id="project-select">
-              <option value="">Loading projects...</option>
-            </select>
+            <div id="timer-project-wrap">
+              <label for="project-select">Project</label>
+              <select id="project-select">
+                <option value="">Loading projects...</option>
+              </select>
+            </div>
             <div class="form-row">
               <div>
                 <label for="timer-description">Description</label>
@@ -174,7 +182,7 @@ export function indexPage() {
                 <input type="text" id="timer-jira" placeholder="e.g. PROJ-123" />
               </div>
             </div>
-            <label style="display:flex; align-items:center; gap:0.5rem; font-weight:normal; cursor:pointer;">
+            <label id="timer-billable-wrap" style="display:flex; align-items:center; gap:0.5rem; font-weight:normal; cursor:pointer;">
               <input type="checkbox" id="timer-billable" checked style="width:auto; margin:0;" />
               Billable
             </label>
@@ -185,10 +193,12 @@ export function indexPage() {
         </div>
 
         <div id="track-manual" style="display:none;">
-          <label for="manual-project">Project</label>
-          <select id="manual-project">
-            <option value="">Loading projects...</option>
-          </select>
+          <div id="manual-project-wrap">
+            <label for="manual-project">Project</label>
+            <select id="manual-project">
+              <option value="">Loading projects...</option>
+            </select>
+          </div>
           <div class="form-row">
             <div>
               <label for="manual-start">Start</label>
@@ -209,13 +219,18 @@ export function indexPage() {
               <input type="text" id="manual-jira" placeholder="e.g. PROJ-123" />
             </div>
           </div>
-          <label style="display:flex; align-items:center; gap:0.5rem; font-weight:normal; cursor:pointer;">
+          <label id="manual-billable-wrap" style="display:flex; align-items:center; gap:0.5rem; font-weight:normal; cursor:pointer;">
             <input type="checkbox" id="manual-billable" checked style="width:auto; margin:0;" />
             Billable
           </label>
           <button id="manual-log-btn" onclick="logManualTime()">Log Time</button>
           <div class="msg" id="manual-msg"></div>
         </div>
+      </div>
+
+      <!-- No provider configured -->
+      <div class="card empty-state-card" id="no-provider-card" style="display:none;">
+        Configure Clockify or Jira in <a href="#" onclick="switchTab('settings');return false;" style="color:#58a6ff;">Settings</a> to start tracking.
       </div>
 
       <!-- Monitor Control -->
@@ -304,6 +319,7 @@ export function indexPage() {
         </div>
         <p id="google-desc" style="font-size:0.85rem;color:#8b949e;margin-bottom:0.5rem;">Authorize access to your Google Calendar.</p>
         <button class="connect" id="google-connect-btn" onclick="connectGoogle()">Connect Google Account</button>
+        <p id="google-connect-note" style="font-size:0.75rem;color:#8b949e;margin-top:0.5rem;display:none;"></p>
         <div class="msg" id="google-msg"></div>
       </div>
 
@@ -395,10 +411,12 @@ export function indexPage() {
 
     // --- Tab switching ---
     function switchTab(tab) {
+      const nav = document.getElementById('nav-' + tab);
+      if (nav && nav.getAttribute('aria-disabled') === 'true') return;
       document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
       document.querySelectorAll('.nav-btn').forEach(el => el.classList.remove('active'));
       document.getElementById('tab-' + tab).classList.add('active');
-      document.getElementById('nav-' + tab).classList.add('active');
+      if (nav) nav.classList.add('active');
     }
 
     function switchTrackMode(mode) {
@@ -893,7 +911,7 @@ export function indexPage() {
             : '';
           return '<tr>' +
             '<td>' + escapeHtml(s.description) + '</td>' +
-            '<td>' + escapeHtml(s.projectName) + '</td>' +
+            '<td>' + (s.projectName ? escapeHtml(s.projectName) : '—') + '</td>' +
             '<td>' + started + '</td>' +
             '<td>' + duration + '</td>' +
             '<td>' + escapeHtml(jira) + '</td>' +
@@ -1101,6 +1119,84 @@ export function indexPage() {
     }
 
     // --- Status ---
+    function applyMode(data) {
+      const clockifyOn = !!data.clockify;
+      const jiraOn = !!data.jira;
+      const noProvider = !clockifyOn && !jiraOn;
+
+      // Header mode pill
+      const pill = document.getElementById('mode-pill');
+      if (pill) pill.style.display = (!clockifyOn && jiraOn) ? 'inline-block' : 'none';
+
+      // Timer form: hide project + mark Jira required in Jira-only; hide entire form when no provider
+      const trackCard = document.getElementById('track-card');
+      const noProviderCard = document.getElementById('no-provider-card');
+      const projWrap = document.getElementById('timer-project-wrap');
+      const manualProjWrap = document.getElementById('manual-project-wrap');
+      const chip = document.getElementById('track-mode-chip');
+      const jiraInput = document.getElementById('timer-jira');
+      const manualJiraInput = document.getElementById('manual-jira');
+      const billableWrap = document.getElementById('timer-billable-wrap');
+      const manualBillableWrap = document.getElementById('manual-billable-wrap');
+
+      if (noProvider) {
+        if (trackCard) trackCard.style.display = 'none';
+        if (noProviderCard) noProviderCard.style.display = '';
+      } else {
+        if (trackCard) trackCard.style.display = '';
+        if (noProviderCard) noProviderCard.style.display = 'none';
+        if (clockifyOn) {
+          if (projWrap) projWrap.style.display = '';
+          if (manualProjWrap) manualProjWrap.style.display = '';
+          if (chip) chip.style.display = 'none';
+          if (jiraInput) jiraInput.required = false;
+          if (manualJiraInput) manualJiraInput.required = false;
+          if (billableWrap) billableWrap.style.display = '';
+          if (manualBillableWrap) manualBillableWrap.style.display = '';
+        } else {
+          if (projWrap) projWrap.style.display = 'none';
+          if (manualProjWrap) manualProjWrap.style.display = 'none';
+          if (chip) chip.style.display = 'inline-block';
+          if (jiraInput) jiraInput.required = true;
+          if (manualJiraInput) manualJiraInput.required = true;
+          if (billableWrap) billableWrap.style.display = 'none';
+          if (manualBillableWrap) manualBillableWrap.style.display = 'none';
+        }
+      }
+
+      // Projects tab: hide "Pull from Clockify" button
+      const pullBtn = document.getElementById('fetch-projects-btn');
+      if (pullBtn) pullBtn.style.display = clockifyOn ? '' : 'none';
+
+      // Calendar tab: disable nav when Clockify off
+      const calNav = document.getElementById('nav-calendar');
+      if (calNav) {
+        if (clockifyOn) {
+          calNav.removeAttribute('aria-disabled');
+          calNav.classList.remove('is-disabled');
+          calNav.title = '';
+        } else {
+          calNav.setAttribute('aria-disabled', 'true');
+          calNav.classList.add('is-disabled');
+          calNav.title = 'Calendar sync requires Clockify.';
+        }
+      }
+
+      // Settings: Google Connect button — disable when Clockify off
+      const gBtn = document.getElementById('google-connect-btn');
+      const gNote = document.getElementById('google-connect-note');
+      if (gBtn) gBtn.disabled = !clockifyOn;
+      if (gNote) {
+        if (clockifyOn) {
+          gNote.textContent = '';
+          gNote.style.display = 'none';
+        } else {
+          gNote.textContent = 'Calendar sync requires Clockify. Connect Clockify first.';
+          gNote.style.display = '';
+        }
+      }
+    }
+
     async function fetchStatus() {
       try {
         const res = await fetch('/api/status');
@@ -1113,6 +1209,7 @@ export function indexPage() {
         }
         setGoogleConnected(data.google, data.googleEmail);
         setJiraConnected(data.jira, data.jiraOAuth, data.jiraSiteUrl);
+        applyMode(data);
       } catch {}
     }
 

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -134,7 +134,7 @@ export function indexPage() {
     .local-hint a { color: #58a6ff; }
 
     #ctx-menu { position: fixed; display: none; z-index: 9999; background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 0.25rem; min-width: 140px; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
-    #ctx-menu button { display: block; width: 100%; text-align: left; background: transparent; border: none; color: #e1e4e8; padding: 0.4rem 0.7rem; border-radius: 4px; font-size: 0.85rem; cursor: pointer; }
+    #ctx-menu button { display: block; width: 100%; margin: 0; text-align: left; background: transparent; border: none; color: #e1e4e8; padding: 0.4rem 0.7rem; border-radius: 4px; font-size: 0.85rem; cursor: pointer; }
     #ctx-menu button:hover { background: #21262d; }
 
   </style>
@@ -347,6 +347,13 @@ export function indexPage() {
         </div>
         <p id="jira-desc" style="font-size:0.85rem;color:#8b949e;margin-bottom:0.5rem;">Connect your Atlassian account to log time on Jira tickets.</p>
         <button class="connect" id="jira-connect-btn" onclick="connectJira()">Connect Atlassian</button>
+        <div style="display:flex; align-items:center; gap:0.6rem; margin-top:0.75rem;">
+          <label class="toggle">
+            <input type="checkbox" id="jira-enabled-toggle" onchange="toggleJiraEnabled()" />
+            <span class="slider"></span>
+          </label>
+          <span id="jira-enabled-label" style="font-size:0.9rem; color:#8b949e;">Enabled</span>
+        </div>
         <div class="msg" id="jira-msg"></div>
         <div style="margin-top:1rem;">
           <a href="#" id="jira-toggle" onclick="toggleJiraForm(event)" style="font-size:0.8rem;color:#8b949e;text-decoration:none;">or use API token &darr;</a>
@@ -1171,6 +1178,27 @@ export function indexPage() {
       }
     }
 
+    async function toggleJiraEnabled() {
+      const enabled = document.getElementById('jira-enabled-toggle').checked;
+      document.getElementById('jira-enabled-label').textContent = enabled ? 'Enabled' : 'Disabled';
+      try {
+        const res = await fetch('/api/jira/enabled', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled }),
+        });
+        const data = await res.json();
+        if (data.ok) {
+          setMsg('jira-msg', enabled ? 'Jira enabled.' : 'Jira disabled.', true);
+          fetchStatus();
+        } else {
+          setMsg('jira-msg', data.error || 'Failed to update.', false);
+        }
+      } catch {
+        setMsg('jira-msg', 'Request failed.', false);
+      }
+    }
+
     async function saveJira() {
       const url = document.getElementById('jira-url').value.trim();
       const email = document.getElementById('jira-email').value.trim();
@@ -1295,8 +1323,8 @@ export function indexPage() {
         if (manualDescWrap) manualDescWrap.style.display = '';
         if (descPreview) descPreview.style.display = 'none';
         if (manualDescPreview) manualDescPreview.style.display = 'none';
-        if (jiraWrap) jiraWrap.style.display = '';
-        if (manualJiraWrap) manualJiraWrap.style.display = '';
+        if (jiraWrap) jiraWrap.style.display = jiraOn ? '' : 'none';
+        if (manualJiraWrap) manualJiraWrap.style.display = jiraOn ? '' : 'none';
         if (jiraInput) jiraInput.required = false;
         if (manualJiraInput) manualJiraInput.required = false;
         if (jiraLabel) jiraLabel.textContent = 'Jira Ticket (optional)';
@@ -1382,6 +1410,16 @@ export function indexPage() {
         if (toggleLabel) toggleLabel.textContent = enabled ? 'Enabled' : 'Disabled';
         if (keyInput) keyInput.disabled = !enabled;
         if (saveBtn) saveBtn.disabled = !enabled;
+
+        const jToggle = document.getElementById('jira-enabled-toggle');
+        const jToggleLabel = document.getElementById('jira-enabled-label');
+        const jConnectBtn = document.getElementById('jira-connect-btn');
+        const jToggleWrap = jToggle ? jToggle.closest('label').parentElement : null;
+        const jiraEnabled = !data.jiraDisabled;
+        if (jToggle) jToggle.checked = jiraEnabled;
+        if (jToggleLabel) jToggleLabel.textContent = jiraEnabled ? 'Enabled' : 'Disabled';
+        if (jToggleWrap) jToggleWrap.style.display = data.jiraConfigured ? '' : 'none';
+        if (jConnectBtn) jConnectBtn.disabled = data.jiraConfigured && !jiraEnabled;
         setGoogleConnected(data.google, data.googleEmail);
         setJiraConnected(data.jira, data.jiraOAuth, data.jiraSiteUrl);
         applyMode(data);

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -1149,9 +1149,11 @@ export function indexPage() {
       var el = document.getElementById(previewId);
       if (!el) return;
       if (!ticket) {
-        el.innerHTML = '<span class="ticket-hint">Enter a Jira ticket above to preview the description.</span>';
+        el.style.display = 'none';
+        el.innerHTML = '';
         return;
       }
+      el.style.display = '';
       if (description) {
         el.innerHTML = '<span class="ticket-id">' + escapeHtml(ticket) + '</span>' + escapeHtml(description);
       } else {

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -1331,12 +1331,8 @@ export function indexPage() {
         }
         const toggle = document.getElementById('clockify-enabled-toggle');
         const toggleLabel = document.getElementById('clockify-enabled-label');
-        const hasKey = !!data.clockifyKeyHint;
-        const enabled = hasKey && !data.clockifyDisabled;
-        if (toggle) {
-          toggle.checked = enabled;
-          toggle.disabled = !hasKey;
-        }
+        const enabled = !data.clockifyDisabled;
+        if (toggle) toggle.checked = enabled;
         if (toggleLabel) toggleLabel.textContent = enabled ? 'Enabled' : 'Disabled';
         setGoogleConnected(data.google, data.googleEmail);
         setJiraConnected(data.jira, data.jiraOAuth, data.jiraSiteUrl);

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -130,6 +130,8 @@ export function indexPage() {
     .ticket-preview .ticket-id { color: #58a6ff; font-weight: 600; margin-right: 0.4rem; }
     .ticket-preview .ticket-hint { color: #8b949e; font-style: italic; }
     .ticket-preview .ticket-error { color: #f85149; }
+    .local-hint { margin-top: 0.4rem; color: #8b949e; font-size: 0.8rem; font-style: italic; }
+    .local-hint a { color: #58a6ff; }
 
   </style>
 </head>
@@ -176,6 +178,7 @@ export function indexPage() {
               <div id="timer-description-wrap">
                 <label for="timer-description">Description</label>
                 <input type="text" id="timer-description" placeholder="What are you working on?" />
+                <div id="timer-local-hint" class="local-hint" style="display:none;">Time will be logged locally only. Configure Clockify or Jira in <a href="#" onclick="switchTab('settings');return false;">Settings</a> to sync.</div>
               </div>
               <div>
                 <label for="timer-jira" id="timer-jira-label">Jira Ticket (optional)</label>
@@ -214,6 +217,7 @@ export function indexPage() {
             <div id="manual-description-wrap">
               <label for="manual-description">Description</label>
               <input type="text" id="manual-description" placeholder="What did you work on?" />
+              <div id="manual-local-hint" class="local-hint" style="display:none;">Time will be logged locally only. Configure Clockify or Jira in <a href="#" onclick="switchTab('settings');return false;">Settings</a> to sync.</div>
             </div>
             <div>
               <label for="manual-jira" id="manual-jira-label">Jira Ticket (optional)</label>
@@ -230,10 +234,6 @@ export function indexPage() {
         </div>
       </div>
 
-      <!-- Local-only banner when no provider is configured -->
-      <div class="card empty-state-card" id="local-only-banner" style="display:none;">
-        Time will be logged locally only. Configure Clockify or Jira in <a href="#" onclick="switchTab('settings');return false;" style="color:#58a6ff;">Settings</a> to sync.
-      </div>
 
       <!-- Monitor Control -->
       <div class="card">
@@ -1244,7 +1244,8 @@ export function indexPage() {
       currentMode.jiraOn = jiraOn;
 
       const trackCard = document.getElementById('track-card');
-      const localBanner = document.getElementById('local-only-banner');
+      const timerLocalHint = document.getElementById('timer-local-hint');
+      const manualLocalHint = document.getElementById('manual-local-hint');
       const projWrap = document.getElementById('timer-project-wrap');
       const manualProjWrap = document.getElementById('manual-project-wrap');
       const descWrap = document.getElementById('timer-description-wrap');
@@ -1261,7 +1262,8 @@ export function indexPage() {
       const manualBillableWrap = document.getElementById('manual-billable-wrap');
 
       if (trackCard) trackCard.style.display = '';
-      if (localBanner) localBanner.style.display = localOnly ? '' : 'none';
+      if (timerLocalHint) timerLocalHint.style.display = localOnly ? '' : 'none';
+      if (manualLocalHint) manualLocalHint.style.display = localOnly ? '' : 'none';
 
       if (clockifyOn) {
         if (projWrap) projWrap.style.display = '';

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -310,6 +310,11 @@ export function indexPage() {
         <label for="clockify-key">API Key</label>
         <input type="password" id="clockify-key" placeholder="Enter your Clockify API key" />
         <button onclick="saveClockify()">Save &amp; Validate</button>
+        <label class="toggle" style="margin-top:0.75rem;">
+          <input type="checkbox" id="clockify-enabled-toggle" onchange="toggleClockifyEnabled()" />
+          <span class="slider"></span>
+          <span id="clockify-enabled-label">Enabled</span>
+        </label>
         <div class="msg" id="clockify-msg"></div>
       </div>
 
@@ -1041,6 +1046,27 @@ export function indexPage() {
       }
     }
 
+    async function toggleClockifyEnabled() {
+      const enabled = document.getElementById('clockify-enabled-toggle').checked;
+      document.getElementById('clockify-enabled-label').textContent = enabled ? 'Enabled' : 'Disabled';
+      try {
+        const res = await fetch('/api/clockify/enabled', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ enabled }),
+        });
+        const data = await res.json();
+        if (data.ok) {
+          setMsg('clockify-msg', enabled ? 'Clockify enabled.' : 'Clockify disabled.', true);
+          fetchStatus();
+        } else {
+          setMsg('clockify-msg', data.error || 'Failed to update.', false);
+        }
+      } catch {
+        setMsg('clockify-msg', 'Request failed.', false);
+      }
+    }
+
     // --- Settings: Google ---
     function setGoogleConnected(connected, email) {
       const btn = document.getElementById('google-connect-btn');
@@ -1301,6 +1327,15 @@ export function indexPage() {
         if (data.clockifyKeyHint) {
           document.getElementById('clockify-key').placeholder = data.clockifyKeyHint;
         }
+        const toggle = document.getElementById('clockify-enabled-toggle');
+        const toggleLabel = document.getElementById('clockify-enabled-label');
+        const hasKey = !!data.clockifyKeyHint;
+        const enabled = hasKey && !data.clockifyDisabled;
+        if (toggle) {
+          toggle.checked = enabled;
+          toggle.disabled = !hasKey;
+        }
+        if (toggleLabel) toggleLabel.textContent = enabled ? 'Enabled' : 'Disabled';
         setGoogleConnected(data.google, data.googleEmail);
         setJiraConnected(data.jira, data.jiraOAuth, data.jiraSiteUrl);
         applyMode(data);

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -230,9 +230,9 @@ export function indexPage() {
         </div>
       </div>
 
-      <!-- No provider configured -->
-      <div class="card empty-state-card" id="no-provider-card" style="display:none;">
-        Configure Clockify or Jira in <a href="#" onclick="switchTab('settings');return false;" style="color:#58a6ff;">Settings</a> to start tracking.
+      <!-- Local-only banner when no provider is configured -->
+      <div class="card empty-state-card" id="local-only-banner" style="display:none;">
+        Time will be logged locally only. Configure Clockify or Jira in <a href="#" onclick="switchTab('settings');return false;" style="color:#58a6ff;">Settings</a> to sync.
       </div>
 
       <!-- Monitor Control -->
@@ -505,13 +505,15 @@ export function indexPage() {
       const jiraTicket = document.getElementById('timer-jira').value.trim();
       const billable = document.getElementById('timer-billable').checked;
       const typedDescription = document.getElementById('timer-description').value.trim();
-      const description = currentMode.clockifyOn ? typedDescription : '';
+      const description = typedDescription;
 
       if (currentMode.clockifyOn) {
         if (!projectId) return setMsg('timer-msg', 'Please select a project.', false);
         if (!typedDescription && !jiraTicket) return setMsg('timer-msg', 'Please enter a description or Jira ticket.', false);
-      } else {
+      } else if (currentMode.jiraOn) {
         if (!jiraTicket) return setMsg('timer-msg', 'Please enter a Jira ticket.', false);
+      } else {
+        if (!typedDescription) return setMsg('timer-msg', 'Please enter a description.', false);
       }
 
       const btn = document.getElementById('start-btn');
@@ -524,7 +526,7 @@ export function indexPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             projectId: projectId || undefined,
-            description: currentMode.clockifyOn ? (description || 'Working on a task...') : '',
+            description: currentMode.clockifyOn ? (description || 'Working on a task...') : description,
             jiraTicket: jiraTicket || undefined,
             billable,
           }),
@@ -590,7 +592,7 @@ export function indexPage() {
       const typedDescription = document.getElementById('manual-description').value.trim();
       const jiraTicket = document.getElementById('manual-jira').value.trim();
       const billable = document.getElementById('manual-billable').checked;
-      const description = currentMode.clockifyOn ? typedDescription : '';
+      const description = typedDescription;
 
       if (!startVal || !endVal) return setMsg('manual-msg', 'Please set start and end.', false);
 
@@ -602,8 +604,10 @@ export function indexPage() {
       if (currentMode.clockifyOn) {
         if (!projectId) return setMsg('manual-msg', 'Please select a project.', false);
         if (!typedDescription && !jiraTicket) return setMsg('manual-msg', 'Please enter a description or Jira ticket.', false);
-      } else {
+      } else if (currentMode.jiraOn) {
         if (!jiraTicket) return setMsg('manual-msg', 'Please enter a Jira ticket.', false);
+      } else {
+        if (!typedDescription) return setMsg('manual-msg', 'Please enter a description.', false);
       }
 
       const btn = document.getElementById('manual-log-btn');
@@ -1235,13 +1239,12 @@ export function indexPage() {
     function applyMode(data) {
       const clockifyOn = !!data.clockify;
       const jiraOn = !!data.jira;
-      const noProvider = !clockifyOn && !jiraOn;
+      const localOnly = !clockifyOn && !jiraOn;
       currentMode.clockifyOn = clockifyOn;
       currentMode.jiraOn = jiraOn;
 
-      // Timer form: hide project + mark Jira required in Jira-only; hide entire form when no provider
       const trackCard = document.getElementById('track-card');
-      const noProviderCard = document.getElementById('no-provider-card');
+      const localBanner = document.getElementById('local-only-banner');
       const projWrap = document.getElementById('timer-project-wrap');
       const manualProjWrap = document.getElementById('manual-project-wrap');
       const descWrap = document.getElementById('timer-description-wrap');
@@ -1252,44 +1255,60 @@ export function indexPage() {
       const manualJiraInput = document.getElementById('manual-jira');
       const jiraLabel = document.getElementById('timer-jira-label');
       const manualJiraLabel = document.getElementById('manual-jira-label');
+      const jiraWrap = jiraInput ? jiraInput.closest('.row') || jiraInput.parentElement : null;
+      const manualJiraWrap = manualJiraInput ? manualJiraInput.closest('.row') || manualJiraInput.parentElement : null;
       const billableWrap = document.getElementById('timer-billable-wrap');
       const manualBillableWrap = document.getElementById('manual-billable-wrap');
 
-      if (noProvider) {
-        if (trackCard) trackCard.style.display = 'none';
-        if (noProviderCard) noProviderCard.style.display = '';
+      if (trackCard) trackCard.style.display = '';
+      if (localBanner) localBanner.style.display = localOnly ? '' : 'none';
+
+      if (clockifyOn) {
+        if (projWrap) projWrap.style.display = '';
+        if (manualProjWrap) manualProjWrap.style.display = '';
+        if (descWrap) descWrap.style.display = '';
+        if (manualDescWrap) manualDescWrap.style.display = '';
+        if (descPreview) descPreview.style.display = 'none';
+        if (manualDescPreview) manualDescPreview.style.display = 'none';
+        if (jiraWrap) jiraWrap.style.display = '';
+        if (manualJiraWrap) manualJiraWrap.style.display = '';
+        if (jiraInput) jiraInput.required = false;
+        if (manualJiraInput) manualJiraInput.required = false;
+        if (jiraLabel) jiraLabel.textContent = 'Jira Ticket (optional)';
+        if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket (optional)';
+        if (billableWrap) billableWrap.style.display = '';
+        if (manualBillableWrap) manualBillableWrap.style.display = '';
+      } else if (jiraOn) {
+        if (projWrap) projWrap.style.display = 'none';
+        if (manualProjWrap) manualProjWrap.style.display = 'none';
+        if (descWrap) descWrap.style.display = 'none';
+        if (manualDescWrap) manualDescWrap.style.display = 'none';
+        if (descPreview) { descPreview.style.display = ''; renderTicketPreview('timer-description-preview', (jiraInput ? jiraInput.value.trim().toUpperCase() : ''), timerJiraSummary); }
+        if (manualDescPreview) { manualDescPreview.style.display = ''; renderTicketPreview('manual-description-preview', (manualJiraInput ? manualJiraInput.value.trim().toUpperCase() : ''), manualJiraSummary); }
+        if (jiraWrap) jiraWrap.style.display = '';
+        if (manualJiraWrap) manualJiraWrap.style.display = '';
+        if (jiraInput) jiraInput.required = true;
+        if (manualJiraInput) manualJiraInput.required = true;
+        if (jiraLabel) jiraLabel.textContent = 'Jira Ticket';
+        if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket';
+        if (billableWrap) billableWrap.style.display = 'none';
+        if (manualBillableWrap) manualBillableWrap.style.display = 'none';
+        onTimerJiraInput();
+        onManualJiraInput();
       } else {
-        if (trackCard) trackCard.style.display = '';
-        if (noProviderCard) noProviderCard.style.display = 'none';
-        if (clockifyOn) {
-          if (projWrap) projWrap.style.display = '';
-          if (manualProjWrap) manualProjWrap.style.display = '';
-          if (descWrap) descWrap.style.display = '';
-          if (manualDescWrap) manualDescWrap.style.display = '';
-          if (descPreview) descPreview.style.display = 'none';
-          if (manualDescPreview) manualDescPreview.style.display = 'none';
-          if (jiraInput) jiraInput.required = false;
-          if (manualJiraInput) manualJiraInput.required = false;
-          if (jiraLabel) jiraLabel.textContent = 'Jira Ticket (optional)';
-          if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket (optional)';
-          if (billableWrap) billableWrap.style.display = '';
-          if (manualBillableWrap) manualBillableWrap.style.display = '';
-        } else {
-          if (projWrap) projWrap.style.display = 'none';
-          if (manualProjWrap) manualProjWrap.style.display = 'none';
-          if (descWrap) descWrap.style.display = 'none';
-          if (manualDescWrap) manualDescWrap.style.display = 'none';
-          if (descPreview) { descPreview.style.display = ''; renderTicketPreview('timer-description-preview', (jiraInput ? jiraInput.value.trim().toUpperCase() : ''), timerJiraSummary); }
-          if (manualDescPreview) { manualDescPreview.style.display = ''; renderTicketPreview('manual-description-preview', (manualJiraInput ? manualJiraInput.value.trim().toUpperCase() : ''), manualJiraSummary); }
-          if (jiraInput) jiraInput.required = true;
-          if (manualJiraInput) manualJiraInput.required = true;
-          if (jiraLabel) jiraLabel.textContent = 'Jira Ticket';
-          if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket';
-          if (billableWrap) billableWrap.style.display = 'none';
-          if (manualBillableWrap) manualBillableWrap.style.display = 'none';
-          onTimerJiraInput();
-          onManualJiraInput();
-        }
+        // Local-only: description only
+        if (projWrap) projWrap.style.display = 'none';
+        if (manualProjWrap) manualProjWrap.style.display = 'none';
+        if (descWrap) descWrap.style.display = '';
+        if (manualDescWrap) manualDescWrap.style.display = '';
+        if (descPreview) descPreview.style.display = 'none';
+        if (manualDescPreview) manualDescPreview.style.display = 'none';
+        if (jiraWrap) jiraWrap.style.display = 'none';
+        if (manualJiraWrap) manualJiraWrap.style.display = 'none';
+        if (jiraInput) jiraInput.required = false;
+        if (manualJiraInput) manualJiraInput.required = false;
+        if (billableWrap) billableWrap.style.display = 'none';
+        if (manualBillableWrap) manualBillableWrap.style.display = 'none';
       }
 
       // Projects tab: hide "Pull from Clockify" button

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -517,7 +517,7 @@ export function indexPage() {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             projectId: projectId || undefined,
-            description: description || 'Working on a task...',
+            description: currentMode.clockifyOn ? (description || 'Working on a task...') : '',
             jiraTicket: jiraTicket || undefined,
             billable,
           }),

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -1159,14 +1159,14 @@ export function indexPage() {
       if (description) {
         el.innerHTML = '<span class="ticket-id">' + escapeHtml(ticket) + '</span>' + escapeHtml(description);
       } else {
-        el.innerHTML = '<span class="ticket-id">' + escapeHtml(ticket) + '</span><span class="ticket-hint">No prior description on file. We will log with the ticket id.</span>';
+        el.innerHTML = '<span class="ticket-id">' + escapeHtml(ticket) + '</span><span class="ticket-hint">Could not fetch title from Jira. We will log with the ticket id.</span>';
       }
     }
 
-    async function fetchLastDescription(ticket) {
+    async function fetchTicketSummary(ticket) {
       if (!/^[A-Z][A-Z0-9]+-\d+$/.test(ticket)) return null;
       try {
-        const res = await fetch('/api/sessions/last-description?jira=' + encodeURIComponent(ticket));
+        const res = await fetch('/api/jira/ticket-summary?jira=' + encodeURIComponent(ticket));
         const data = await res.json();
         if (data.ok) return data.description || '';
       } catch {}
@@ -1185,7 +1185,7 @@ export function indexPage() {
     async function onTimerJiraInput() {
       var ticket = document.getElementById('timer-jira').value.trim().toUpperCase();
       if (!currentMode.clockifyOn) {
-        var desc = await fetchLastDescription(ticket);
+        var desc = await fetchTicketSummary(ticket);
         timerJiraSummary = desc || '';
         renderTicketPreview('timer-description-preview', ticket, timerJiraSummary);
       }
@@ -1193,7 +1193,7 @@ export function indexPage() {
     async function onManualJiraInput() {
       var ticket = document.getElementById('manual-jira').value.trim().toUpperCase();
       if (!currentMode.clockifyOn) {
-        var desc = await fetchLastDescription(ticket);
+        var desc = await fetchTicketSummary(ticket);
         manualJiraSummary = desc || '';
         renderTicketPreview('manual-description-preview', ticket, manualJiraSummary);
       }

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -161,7 +161,9 @@ export function indexPage() {
         <div class="track-tabs" id="track-tabs">
           <button class="track-tab-btn active" data-mode="auto" onclick="switchTrackMode('auto')">Auto Track</button>
           <button class="track-tab-btn" data-mode="manual" onclick="switchTrackMode('manual')">Manual Log</button>
-          <span id="track-mode-chip" class="mode-chip" style="display:none;">Jira-only mode</span>
+        </div>
+        <div id="track-mode-chip-row" style="display:none; margin-bottom:0.75rem;">
+          <span id="track-mode-chip" class="mode-chip">Jira-only mode</span>
         </div>
 
         <div id="track-auto">
@@ -178,7 +180,7 @@ export function indexPage() {
                 <input type="text" id="timer-description" placeholder="What are you working on?" />
               </div>
               <div>
-                <label for="timer-jira">Jira Ticket (optional)</label>
+                <label for="timer-jira" id="timer-jira-label">Jira Ticket (optional)</label>
                 <input type="text" id="timer-jira" placeholder="e.g. PROJ-123" />
               </div>
             </div>
@@ -215,7 +217,7 @@ export function indexPage() {
               <input type="text" id="manual-description" placeholder="What did you work on?" />
             </div>
             <div>
-              <label for="manual-jira">Jira Ticket (optional)</label>
+              <label for="manual-jira" id="manual-jira-label">Jira Ticket (optional)</label>
               <input type="text" id="manual-jira" placeholder="e.g. PROJ-123" />
             </div>
           </div>
@@ -1133,9 +1135,11 @@ export function indexPage() {
       const noProviderCard = document.getElementById('no-provider-card');
       const projWrap = document.getElementById('timer-project-wrap');
       const manualProjWrap = document.getElementById('manual-project-wrap');
-      const chip = document.getElementById('track-mode-chip');
+      const chipRow = document.getElementById('track-mode-chip-row');
       const jiraInput = document.getElementById('timer-jira');
       const manualJiraInput = document.getElementById('manual-jira');
+      const jiraLabel = document.getElementById('timer-jira-label');
+      const manualJiraLabel = document.getElementById('manual-jira-label');
       const billableWrap = document.getElementById('timer-billable-wrap');
       const manualBillableWrap = document.getElementById('manual-billable-wrap');
 
@@ -1148,17 +1152,21 @@ export function indexPage() {
         if (clockifyOn) {
           if (projWrap) projWrap.style.display = '';
           if (manualProjWrap) manualProjWrap.style.display = '';
-          if (chip) chip.style.display = 'none';
+          if (chipRow) chipRow.style.display = 'none';
           if (jiraInput) jiraInput.required = false;
           if (manualJiraInput) manualJiraInput.required = false;
+          if (jiraLabel) jiraLabel.textContent = 'Jira Ticket (optional)';
+          if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket (optional)';
           if (billableWrap) billableWrap.style.display = '';
           if (manualBillableWrap) manualBillableWrap.style.display = '';
         } else {
           if (projWrap) projWrap.style.display = 'none';
           if (manualProjWrap) manualProjWrap.style.display = 'none';
-          if (chip) chip.style.display = 'inline-block';
+          if (chipRow) chipRow.style.display = '';
           if (jiraInput) jiraInput.required = true;
           if (manualJiraInput) manualJiraInput.required = true;
+          if (jiraLabel) jiraLabel.textContent = 'Jira Ticket';
+          if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket';
           if (billableWrap) billableWrap.style.display = 'none';
           if (manualBillableWrap) manualBillableWrap.style.display = 'none';
         }
@@ -1168,19 +1176,13 @@ export function indexPage() {
       const pullBtn = document.getElementById('fetch-projects-btn');
       if (pullBtn) pullBtn.style.display = clockifyOn ? '' : 'none';
 
-      // Calendar tab: disable nav when Clockify off
+      // Projects nav: hide entire tab when Clockify off
+      const projectsNav = document.getElementById('nav-projects');
+      if (projectsNav) projectsNav.style.display = clockifyOn ? '' : 'none';
+
+      // Calendar nav: hide entire tab when Clockify off
       const calNav = document.getElementById('nav-calendar');
-      if (calNav) {
-        if (clockifyOn) {
-          calNav.removeAttribute('aria-disabled');
-          calNav.classList.remove('is-disabled');
-          calNav.title = '';
-        } else {
-          calNav.setAttribute('aria-disabled', 'true');
-          calNav.classList.add('is-disabled');
-          calNav.title = 'Calendar sync requires Clockify.';
-        }
-      }
+      if (calNav) calNav.style.display = clockifyOn ? '' : 'none';
 
       // Settings: Google Connect button — disable when Clockify off
       const gBtn = document.getElementById('google-connect-btn');

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -133,9 +133,16 @@ export function indexPage() {
     .local-hint { margin-top: 0.4rem; color: #8b949e; font-size: 0.8rem; font-style: italic; }
     .local-hint a { color: #58a6ff; }
 
+    #ctx-menu { position: fixed; display: none; z-index: 9999; background: #161b22; border: 1px solid #30363d; border-radius: 6px; padding: 0.25rem; min-width: 140px; box-shadow: 0 4px 12px rgba(0,0,0,0.4); }
+    #ctx-menu button { display: block; width: 100%; text-align: left; background: transparent; border: none; color: #e1e4e8; padding: 0.4rem 0.7rem; border-radius: 4px; font-size: 0.85rem; cursor: pointer; }
+    #ctx-menu button:hover { background: #21262d; }
+
   </style>
 </head>
-<body oncontextmenu="return false;">
+<body>
+  <div id="ctx-menu">
+    <button type="button" onclick="location.reload()">Reload</button>
+  </div>
   <div class="header">
     <h1>Clocktopus</h1>
     <div class="nav">
@@ -409,10 +416,26 @@ export function indexPage() {
   </div>
 
   <script>
-    // Disable WebKit's Back/Forward/Reload context menu. Capture-phase and
-    // attached on window so it runs before any app handler and wins the race
-    // with the native WKWebView menu.
-    window.addEventListener('contextmenu', e => e.preventDefault(), { capture: true });
+    // Suppress WebKit's Back/Forward menu. Capture-phase wins the race with
+    // the native WKWebView menu. Our custom menu offers Reload only.
+    (function wireContextMenu() {
+      const menu = document.getElementById('ctx-menu');
+      if (!menu) return;
+      const hide = () => { menu.style.display = 'none'; };
+      window.addEventListener('contextmenu', (e) => {
+        e.preventDefault();
+        const pad = 4;
+        const x = Math.min(e.clientX, window.innerWidth - menu.offsetWidth - pad);
+        const y = Math.min(e.clientY, window.innerHeight - menu.offsetHeight - pad);
+        menu.style.left = x + 'px';
+        menu.style.top = y + 'px';
+        menu.style.display = 'block';
+      }, { capture: true });
+      window.addEventListener('click', hide);
+      window.addEventListener('scroll', hide, { capture: true });
+      window.addEventListener('keydown', (e) => { if (e.key === 'Escape') hide(); });
+      window.addEventListener('blur', hide);
+    })();
 
     let elapsedInterval = null;
     let currentPage = 1;

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -126,6 +126,10 @@ export function indexPage() {
     .toggle input:checked + .slider::before { transform: translateX(16px); background: #fff; }
 
     .empty-state-card { padding: 1.5rem; text-align: center; color: #8b949e; font-size: 0.9rem; }
+    .ticket-preview { margin-top: 0.5rem; padding: 0.6rem 0.8rem; border: 1px solid #30363d; border-radius: 6px; background: #161b22; color: #e1e4e8; font-size: 0.85rem; min-height: 2rem; }
+    .ticket-preview .ticket-id { color: #58a6ff; font-weight: 600; margin-right: 0.4rem; }
+    .ticket-preview .ticket-hint { color: #8b949e; font-style: italic; }
+    .ticket-preview .ticket-error { color: #f85149; }
 
   </style>
 </head>
@@ -169,7 +173,7 @@ export function indexPage() {
               </select>
             </div>
             <div class="form-row">
-              <div>
+              <div id="timer-description-wrap">
                 <label for="timer-description">Description</label>
                 <input type="text" id="timer-description" placeholder="What are you working on?" />
               </div>
@@ -178,6 +182,7 @@ export function indexPage() {
                 <input type="text" id="timer-jira" placeholder="e.g. PROJ-123" />
               </div>
             </div>
+            <div id="timer-description-preview" class="ticket-preview" style="display:none;"></div>
             <label id="timer-billable-wrap" style="display:flex; align-items:center; gap:0.5rem; font-weight:normal; cursor:pointer;">
               <input type="checkbox" id="timer-billable" checked style="width:auto; margin:0;" />
               Billable
@@ -206,7 +211,7 @@ export function indexPage() {
             </div>
           </div>
           <div class="form-row">
-            <div>
+            <div id="manual-description-wrap">
               <label for="manual-description">Description</label>
               <input type="text" id="manual-description" placeholder="What did you work on?" />
             </div>
@@ -215,6 +220,7 @@ export function indexPage() {
               <input type="text" id="manual-jira" placeholder="e.g. PROJ-123" />
             </div>
           </div>
+          <div id="manual-description-preview" class="ticket-preview" style="display:none;"></div>
           <label id="manual-billable-wrap" style="display:flex; align-items:center; gap:0.5rem; font-weight:normal; cursor:pointer;">
             <input type="checkbox" id="manual-billable" checked style="width:auto; margin:0;" />
             Billable
@@ -489,12 +495,19 @@ export function indexPage() {
 
     async function startTimer() {
       const projectId = document.getElementById('project-select').value;
-      const description = document.getElementById('timer-description').value.trim();
       const jiraTicket = document.getElementById('timer-jira').value.trim();
       const billable = document.getElementById('timer-billable').checked;
+      const typedDescription = document.getElementById('timer-description').value.trim();
+      const description = currentMode.clockifyOn
+        ? typedDescription
+        : (timerJiraSummary || jiraTicket);
 
-      if (!projectId) return setMsg('timer-msg', 'Please select a project.', false);
-      if (!description && !jiraTicket) return setMsg('timer-msg', 'Please enter a description or Jira ticket.', false);
+      if (currentMode.clockifyOn) {
+        if (!projectId) return setMsg('timer-msg', 'Please select a project.', false);
+        if (!typedDescription && !jiraTicket) return setMsg('timer-msg', 'Please enter a description or Jira ticket.', false);
+      } else {
+        if (!jiraTicket) return setMsg('timer-msg', 'Please enter a Jira ticket.', false);
+      }
 
       const btn = document.getElementById('start-btn');
       btn.disabled = true;
@@ -504,13 +517,20 @@ export function indexPage() {
         const res = await fetch('/api/timer/start', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ projectId, description: description || 'Working on a task...', jiraTicket: jiraTicket || undefined, billable }),
+          body: JSON.stringify({
+            projectId: projectId || undefined,
+            description: description || 'Working on a task...',
+            jiraTicket: jiraTicket || undefined,
+            billable,
+          }),
         });
         const data = await res.json();
         if (data.ok) {
           setMsg('timer-msg', 'Timer started!', true);
           document.getElementById('timer-description').value = '';
           document.getElementById('timer-jira').value = '';
+          timerJiraSummary = '';
+          renderTicketPreview('timer-description-preview', '', '');
           checkActiveTimer();
           loadSessions();
         } else {
@@ -562,18 +582,26 @@ export function indexPage() {
       const projectId = document.getElementById('manual-project').value;
       const startVal = document.getElementById('manual-start').value;
       const endVal = document.getElementById('manual-end').value;
-      const description = document.getElementById('manual-description').value.trim();
+      const typedDescription = document.getElementById('manual-description').value.trim();
       const jiraTicket = document.getElementById('manual-jira').value.trim();
       const billable = document.getElementById('manual-billable').checked;
+      const description = currentMode.clockifyOn
+        ? typedDescription
+        : (manualJiraSummary || jiraTicket);
 
-      if (!projectId) return setMsg('manual-msg', 'Please select a project.', false);
       if (!startVal || !endVal) return setMsg('manual-msg', 'Please set start and end.', false);
 
       const startMs = new Date(startVal).getTime();
       const endMs = new Date(endVal).getTime();
       if (isNaN(startMs) || isNaN(endMs)) return setMsg('manual-msg', 'Invalid date.', false);
       if (endMs <= startMs) return setMsg('manual-msg', 'End must be after start.', false);
-      if (!description && !jiraTicket) return setMsg('manual-msg', 'Please enter a description or Jira ticket.', false);
+
+      if (currentMode.clockifyOn) {
+        if (!projectId) return setMsg('manual-msg', 'Please select a project.', false);
+        if (!typedDescription && !jiraTicket) return setMsg('manual-msg', 'Please enter a description or Jira ticket.', false);
+      } else {
+        if (!jiraTicket) return setMsg('manual-msg', 'Please enter a Jira ticket.', false);
+      }
 
       const btn = document.getElementById('manual-log-btn');
       btn.disabled = true;
@@ -584,7 +612,7 @@ export function indexPage() {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
-            projectId: projectId,
+            projectId: projectId || undefined,
             description: description,
             start: new Date(startMs).toISOString(),
             end: new Date(endMs).toISOString(),
@@ -597,6 +625,8 @@ export function indexPage() {
           setMsg('manual-msg', 'Time logged.', true);
           document.getElementById('manual-description').value = '';
           document.getElementById('manual-jira').value = '';
+          manualJiraSummary = '';
+          renderTicketPreview('manual-description-preview', '', '');
           setManualDefaults();
           loadSessions();
         } else {
@@ -1115,16 +1145,83 @@ export function indexPage() {
     }
 
     // --- Status ---
+    var currentMode = { clockifyOn: true, jiraOn: false };
+    var timerJiraSummary = '';
+    var manualJiraSummary = '';
+
+    function renderTicketPreview(previewId, ticket, description) {
+      var el = document.getElementById(previewId);
+      if (!el) return;
+      if (!ticket) {
+        el.innerHTML = '<span class="ticket-hint">Enter a Jira ticket above to preview the description.</span>';
+        return;
+      }
+      if (description) {
+        el.innerHTML = '<span class="ticket-id">' + escapeHtml(ticket) + '</span>' + escapeHtml(description);
+      } else {
+        el.innerHTML = '<span class="ticket-id">' + escapeHtml(ticket) + '</span><span class="ticket-hint">No prior description on file. We will log with the ticket id.</span>';
+      }
+    }
+
+    async function fetchLastDescription(ticket) {
+      if (!/^[A-Z][A-Z0-9]+-\d+$/.test(ticket)) return null;
+      try {
+        const res = await fetch('/api/sessions/last-description?jira=' + encodeURIComponent(ticket));
+        const data = await res.json();
+        if (data.ok) return data.description || '';
+      } catch {}
+      return null;
+    }
+
+    function debounce(fn, ms) {
+      var t;
+      return function() {
+        var ctx = this, args = arguments;
+        clearTimeout(t);
+        t = setTimeout(function(){ fn.apply(ctx, args); }, ms);
+      };
+    }
+
+    async function onTimerJiraInput() {
+      var ticket = document.getElementById('timer-jira').value.trim().toUpperCase();
+      if (!currentMode.clockifyOn) {
+        var desc = await fetchLastDescription(ticket);
+        timerJiraSummary = desc || '';
+        renderTicketPreview('timer-description-preview', ticket, timerJiraSummary);
+      }
+    }
+    async function onManualJiraInput() {
+      var ticket = document.getElementById('manual-jira').value.trim().toUpperCase();
+      if (!currentMode.clockifyOn) {
+        var desc = await fetchLastDescription(ticket);
+        manualJiraSummary = desc || '';
+        renderTicketPreview('manual-description-preview', ticket, manualJiraSummary);
+      }
+    }
+
+    (function wireTicketPreviewInputs() {
+      var t = document.getElementById('timer-jira');
+      var m = document.getElementById('manual-jira');
+      if (t) t.addEventListener('input', debounce(onTimerJiraInput, 300));
+      if (m) m.addEventListener('input', debounce(onManualJiraInput, 300));
+    })();
+
     function applyMode(data) {
       const clockifyOn = !!data.clockify;
       const jiraOn = !!data.jira;
       const noProvider = !clockifyOn && !jiraOn;
+      currentMode.clockifyOn = clockifyOn;
+      currentMode.jiraOn = jiraOn;
 
       // Timer form: hide project + mark Jira required in Jira-only; hide entire form when no provider
       const trackCard = document.getElementById('track-card');
       const noProviderCard = document.getElementById('no-provider-card');
       const projWrap = document.getElementById('timer-project-wrap');
       const manualProjWrap = document.getElementById('manual-project-wrap');
+      const descWrap = document.getElementById('timer-description-wrap');
+      const manualDescWrap = document.getElementById('manual-description-wrap');
+      const descPreview = document.getElementById('timer-description-preview');
+      const manualDescPreview = document.getElementById('manual-description-preview');
       const jiraInput = document.getElementById('timer-jira');
       const manualJiraInput = document.getElementById('manual-jira');
       const jiraLabel = document.getElementById('timer-jira-label');
@@ -1141,6 +1238,10 @@ export function indexPage() {
         if (clockifyOn) {
           if (projWrap) projWrap.style.display = '';
           if (manualProjWrap) manualProjWrap.style.display = '';
+          if (descWrap) descWrap.style.display = '';
+          if (manualDescWrap) manualDescWrap.style.display = '';
+          if (descPreview) descPreview.style.display = 'none';
+          if (manualDescPreview) manualDescPreview.style.display = 'none';
           if (jiraInput) jiraInput.required = false;
           if (manualJiraInput) manualJiraInput.required = false;
           if (jiraLabel) jiraLabel.textContent = 'Jira Ticket (optional)';
@@ -1150,12 +1251,18 @@ export function indexPage() {
         } else {
           if (projWrap) projWrap.style.display = 'none';
           if (manualProjWrap) manualProjWrap.style.display = 'none';
+          if (descWrap) descWrap.style.display = 'none';
+          if (manualDescWrap) manualDescWrap.style.display = 'none';
+          if (descPreview) { descPreview.style.display = ''; renderTicketPreview('timer-description-preview', (jiraInput ? jiraInput.value.trim().toUpperCase() : ''), timerJiraSummary); }
+          if (manualDescPreview) { manualDescPreview.style.display = ''; renderTicketPreview('manual-description-preview', (manualJiraInput ? manualJiraInput.value.trim().toUpperCase() : ''), manualJiraSummary); }
           if (jiraInput) jiraInput.required = true;
           if (manualJiraInput) manualJiraInput.required = true;
           if (jiraLabel) jiraLabel.textContent = 'Jira Ticket';
           if (manualJiraLabel) manualJiraLabel.textContent = 'Jira Ticket';
           if (billableWrap) billableWrap.style.display = 'none';
           if (manualBillableWrap) manualBillableWrap.style.display = 'none';
+          onTimerJiraInput();
+          onManualJiraInput();
         }
       }
 

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -310,11 +310,13 @@ export function indexPage() {
         <label for="clockify-key">API Key</label>
         <input type="password" id="clockify-key" placeholder="Enter your Clockify API key" />
         <button onclick="saveClockify()">Save &amp; Validate</button>
-        <label class="toggle" style="margin-top:0.75rem;">
-          <input type="checkbox" id="clockify-enabled-toggle" onchange="toggleClockifyEnabled()" />
-          <span class="slider"></span>
-          <span id="clockify-enabled-label">Enabled</span>
-        </label>
+        <div style="display:flex; align-items:center; gap:0.6rem; margin-top:0.75rem;">
+          <label class="toggle">
+            <input type="checkbox" id="clockify-enabled-toggle" onchange="toggleClockifyEnabled()" />
+            <span class="slider"></span>
+          </label>
+          <span id="clockify-enabled-label" style="font-size:0.9rem; color:#8b949e;">Enabled</span>
+        </div>
         <div class="msg" id="clockify-msg"></div>
       </div>
 

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -125,16 +125,13 @@ export function indexPage() {
     .toggle input:checked + .slider { background: #238636; }
     .toggle input:checked + .slider::before { transform: translateX(16px); background: #fff; }
 
-    .is-disabled { opacity: 0.45; pointer-events: none; }
-    .mode-chip { display: inline-block; padding: 0.15rem 0.5rem; margin-left: 0.5rem; border-radius: 999px; font-size: 0.75rem; background: #1f6feb22; color: #58a6ff; }
-    .mode-pill { display: inline-block; padding: 0.15rem 0.6rem; margin-left: 0.5rem; border-radius: 999px; font-size: 0.7rem; background: #1f6feb22; color: #58a6ff; vertical-align: middle; }
     .empty-state-card { padding: 1.5rem; text-align: center; color: #8b949e; font-size: 0.9rem; }
 
   </style>
 </head>
 <body oncontextmenu="return false;">
   <div class="header">
-    <h1>Clocktopus<span id="mode-pill" class="mode-pill" style="display:none;">Jira-only</span></h1>
+    <h1>Clocktopus</h1>
     <div class="nav">
       <button class="nav-btn active" onclick="switchTab('home')" id="nav-home">Home</button>
       <button class="nav-btn" onclick="switchTab('projects')" id="nav-projects">Projects</button>
@@ -161,9 +158,6 @@ export function indexPage() {
         <div class="track-tabs" id="track-tabs">
           <button class="track-tab-btn active" data-mode="auto" onclick="switchTrackMode('auto')">Auto Track</button>
           <button class="track-tab-btn" data-mode="manual" onclick="switchTrackMode('manual')">Manual Log</button>
-        </div>
-        <div id="track-mode-chip-row" style="display:none; margin-bottom:0.75rem;">
-          <span id="track-mode-chip" class="mode-chip">Jira-only mode</span>
         </div>
 
         <div id="track-auto">
@@ -1126,16 +1120,11 @@ export function indexPage() {
       const jiraOn = !!data.jira;
       const noProvider = !clockifyOn && !jiraOn;
 
-      // Header mode pill
-      const pill = document.getElementById('mode-pill');
-      if (pill) pill.style.display = (!clockifyOn && jiraOn) ? 'inline-block' : 'none';
-
       // Timer form: hide project + mark Jira required in Jira-only; hide entire form when no provider
       const trackCard = document.getElementById('track-card');
       const noProviderCard = document.getElementById('no-provider-card');
       const projWrap = document.getElementById('timer-project-wrap');
       const manualProjWrap = document.getElementById('manual-project-wrap');
-      const chipRow = document.getElementById('track-mode-chip-row');
       const jiraInput = document.getElementById('timer-jira');
       const manualJiraInput = document.getElementById('manual-jira');
       const jiraLabel = document.getElementById('timer-jira-label');
@@ -1152,7 +1141,6 @@ export function indexPage() {
         if (clockifyOn) {
           if (projWrap) projWrap.style.display = '';
           if (manualProjWrap) manualProjWrap.style.display = '';
-          if (chipRow) chipRow.style.display = 'none';
           if (jiraInput) jiraInput.required = false;
           if (manualJiraInput) manualJiraInput.required = false;
           if (jiraLabel) jiraLabel.textContent = 'Jira Ticket (optional)';
@@ -1162,7 +1150,6 @@ export function indexPage() {
         } else {
           if (projWrap) projWrap.style.display = 'none';
           if (manualProjWrap) manualProjWrap.style.display = 'none';
-          if (chipRow) chipRow.style.display = '';
           if (jiraInput) jiraInput.required = true;
           if (manualJiraInput) manualJiraInput.required = true;
           if (jiraLabel) jiraLabel.textContent = 'Jira Ticket';

--- a/dashboard/views.ts
+++ b/dashboard/views.ts
@@ -498,9 +498,7 @@ export function indexPage() {
       const jiraTicket = document.getElementById('timer-jira').value.trim();
       const billable = document.getElementById('timer-billable').checked;
       const typedDescription = document.getElementById('timer-description').value.trim();
-      const description = currentMode.clockifyOn
-        ? typedDescription
-        : (timerJiraSummary || jiraTicket);
+      const description = currentMode.clockifyOn ? typedDescription : '';
 
       if (currentMode.clockifyOn) {
         if (!projectId) return setMsg('timer-msg', 'Please select a project.', false);
@@ -585,9 +583,7 @@ export function indexPage() {
       const typedDescription = document.getElementById('manual-description').value.trim();
       const jiraTicket = document.getElementById('manual-jira').value.trim();
       const billable = document.getElementById('manual-billable').checked;
-      const description = currentMode.clockifyOn
-        ? typedDescription
-        : (manualJiraSummary || jiraTicket);
+      const description = currentMode.clockifyOn ? typedDescription : '';
 
       if (!startVal || !endVal) return setMsg('manual-msg', 'Please set start and end.', false);
 

--- a/index.ts
+++ b/index.ts
@@ -220,18 +220,27 @@ program
   .command('monitor:run', { hidden: true })
   .description('Run monitor in foreground (used by PM2).')
   .action(async () => {
-    const { workspaceId, userId } = await getWorkspaceAndUser();
+    const creds = isClockifyEnabled() ? await getWorkspaceAndUser() : { workspaceId: '', userId: '' };
+    const { workspaceId, userId } = creds;
 
     async function stopTimerAndLog(reason: string) {
-      const activeEntry = await clockify.getActiveTimer(workspaceId, userId);
-      if (!activeEntry) return false;
+      const clockifyOn = isClockifyEnabled();
+      const latestSession = getLatestSession();
+
+      if (clockifyOn) {
+        const activeEntry = await clockify.getActiveTimer(workspaceId, userId);
+        if (!activeEntry) return false;
+      } else {
+        if (!latestSession || latestSession.completedAt) return false;
+      }
 
       console.log(chalk.yellow(reason));
       const completedAt = new Date().toISOString();
-      const latestSession = getLatestSession();
 
-      const stoppedEntry = await clockify.stopTimer(workspaceId, userId);
-      if (!stoppedEntry) return false;
+      if (clockifyOn) {
+        const stoppedEntry = await clockify.stopTimer(workspaceId, userId);
+        if (!stoppedEntry) return false;
+      }
 
       completeLatestSession(completedAt, true);
 
@@ -267,23 +276,42 @@ program
       const latestSession = getLatestSession();
       if (!latestSession) return;
 
-      const activeEntry = await clockify.getActiveTimer(workspaceId, userId);
-      if (activeEntry) return;
-
       const twoHoursAgo = Date.now() - 2 * 60 * 60 * 1000;
-      const completedAt = latestSession.completedAt ? new Date(latestSession.completedAt).getTime() : 0;
+      const completedMs = latestSession.completedAt ? new Date(latestSession.completedAt).getTime() : 0;
 
-      const eligible = latestSession.isAutoCompleted && completedAt > twoHoursAgo && !!latestSession.projectId;
+      if (!latestSession.isAutoCompleted || completedMs <= twoHoursAgo) return;
 
-      if (!eligible) return;
+      if (isClockifyEnabled()) {
+        if (!latestSession.projectId) return;
 
-      await clockify.startTimer(
-        workspaceId,
-        latestSession.projectId!,
+        const activeEntry = await clockify.getActiveTimer(workspaceId, userId);
+        if (activeEntry) return;
+
+        await clockify.startTimer(
+          workspaceId,
+          latestSession.projectId,
+          latestSession.description,
+          latestSession.jiraTicket ?? undefined,
+        );
+        console.log(chalk.green('Timer restarted for the last used project.'));
+        lastResumeAt = Date.now();
+        return;
+      }
+
+      // Jira-only resume: new DB session with a fresh uuid, same ticket
+      if (!latestSession.jiraTicket) return;
+      const { v4: uuidv4 } = await import('uuid');
+      const { logSessionStart } = await import('./lib/db.js');
+      const sessionId = uuidv4();
+      const startedAt = new Date().toISOString();
+      logSessionStart(
+        sessionId,
+        latestSession.projectId ?? null,
         latestSession.description,
-        latestSession.jiraTicket ?? undefined,
+        startedAt,
+        latestSession.jiraTicket,
       );
-      console.log(chalk.green('Timer restarted for the last used project.'));
+      console.log(chalk.green(`Resumed Jira timer for ${latestSession.jiraTicket}.`));
       lastResumeAt = Date.now();
     }
 

--- a/index.ts
+++ b/index.ts
@@ -235,7 +235,7 @@ program
 
       await clockify.startTimer(
         workspaceId,
-        latestSession.projectId,
+        latestSession.projectId!,
         latestSession.description,
         latestSession.jiraTicket ?? undefined,
       );

--- a/index.ts
+++ b/index.ts
@@ -10,6 +10,7 @@ import { fileURLToPath } from 'url';
 import { createRequire } from 'module';
 import { execSync } from 'child_process';
 import { completeLatestSession, getLatestSession, setSessionJiraWorklogId } from './lib/db.js';
+import { isClockifyEnabled } from './lib/credentials.js';
 import { stopJiraTimer } from './lib/jira.js';
 import { startDashboard } from './dashboard/server.js';
 import { ensureNativeAddons } from './lib/ensure-native-addons.js';
@@ -73,6 +74,20 @@ program
   .option('-j, --jira <ticket>', 'Jira ticket number')
   .option('--no-billable', 'Mark the time entry as non-billable')
   .action(async (message, options) => {
+    if (!isClockifyEnabled()) {
+      if (!options.jira) {
+        console.error(chalk.red('Jira-only mode requires --jira <ticket>.'));
+        process.exit(1);
+      }
+      const { v4: uuidv4 } = await import('uuid');
+      const { logSessionStart } = await import('./lib/db.js');
+      const sessionId = uuidv4();
+      const startedAt = new Date().toISOString();
+      const description = (message && String(message).trim()) || options.jira;
+      logSessionStart(sessionId, null, description, startedAt, options.jira);
+      console.log(chalk.green(`Timer started for ${chalk.bold(options.jira)} (Jira-only mode).`));
+      return;
+    }
     const { workspaceId } = await getWorkspaceAndUser();
 
     let projects: Project[] = await clockify.getProjects(workspaceId);
@@ -122,50 +137,79 @@ program
   .command('stop')
   .description('Stop the currently running time entry.')
   .action(async () => {
-    const { workspaceId, userId } = await getWorkspaceAndUser();
     const latestSession = getLatestSession();
-    const stoppedEntry = await clockify.stopTimer(workspaceId, userId);
-    if (stoppedEntry) {
-      const completedAt = new Date().toISOString();
-      completeLatestSession(completedAt);
-      if (latestSession.jiraTicket) {
-        const timeSpentSeconds = Math.round(
-          (new Date(completedAt).getTime() - new Date(latestSession.startedAt).getTime()) / 1000,
-        );
-        if (timeSpentSeconds >= 60) {
-          try {
-            const worklog = await stopJiraTimer(latestSession.jiraTicket, timeSpentSeconds);
-            if (worklog?.id) setSessionJiraWorklogId(latestSession.id, worklog.id);
-          } catch (error) {
-            console.error('Error stopping Jira timer:', error);
-          }
+
+    if (isClockifyEnabled()) {
+      const { workspaceId, userId } = await getWorkspaceAndUser();
+      const stoppedEntry = await clockify.stopTimer(workspaceId, userId);
+      if (!stoppedEntry) {
+        console.log(chalk.yellow('No timer was running.'));
+        return;
+      }
+    } else {
+      if (!latestSession || latestSession.completedAt) {
+        console.log(chalk.yellow('No timer was running.'));
+        return;
+      }
+    }
+
+    const completedAt = new Date().toISOString();
+    completeLatestSession(completedAt);
+
+    if (latestSession?.jiraTicket) {
+      const timeSpentSeconds = Math.round(
+        (new Date(completedAt).getTime() - new Date(latestSession.startedAt).getTime()) / 1000,
+      );
+      if (timeSpentSeconds >= 60) {
+        try {
+          const worklog = await stopJiraTimer(latestSession.jiraTicket, timeSpentSeconds);
+          if (worklog?.id) setSessionJiraWorklogId(latestSession.id, worklog.id);
+        } catch (error) {
+          console.error('Error stopping Jira timer:', error);
         }
       }
-      console.log(chalk.red('Timer stopped.'));
-    } else {
-      console.log(chalk.yellow('No timer was running.'));
     }
+    console.log(chalk.red('Timer stopped.'));
   });
 
 program
   .command('status')
   .description('Check the status of the current timer.')
   .action(async () => {
-    const { workspaceId, userId } = await getWorkspaceAndUser();
-    const activeEntry = await clockify.getActiveTimer(workspaceId, userId);
+    if (isClockifyEnabled()) {
+      const { workspaceId, userId } = await getWorkspaceAndUser();
+      const activeEntry = await clockify.getActiveTimer(workspaceId, userId);
 
-    if (activeEntry) {
-      const startTime = new Date(activeEntry.timeInterval.start);
-      const duration = (new Date().getTime() - startTime.getTime()) / 1000; // in seconds
-      const hours = Math.floor(duration / 3600);
-      const minutes = Math.floor((duration % 3600) / 60);
+      if (activeEntry) {
+        const startTime = new Date(activeEntry.timeInterval.start);
+        const duration = (new Date().getTime() - startTime.getTime()) / 1000;
+        const hours = Math.floor(duration / 3600);
+        const minutes = Math.floor((duration % 3600) / 60);
 
-      console.log(chalk.green('🕒 A timer is currently running.'));
-      console.log(`   - ${chalk.bold('Project:')} ${activeEntry.project.name}`);
-      console.log(`   - ${chalk.bold('Running for:')} ${hours}h ${minutes}m`);
-    } else {
+        console.log(chalk.green('🕒 A timer is currently running.'));
+        console.log(`   - ${chalk.bold('Project:')} ${activeEntry.project.name}`);
+        console.log(`   - ${chalk.bold('Running for:')} ${hours}h ${minutes}m`);
+        return;
+      }
       console.log(chalk.yellow('No timer is currently running.'));
+      return;
     }
+
+    // Jira-only mode: read from DB
+    const { getOpenSession } = await import('./lib/db.js');
+    const open = getOpenSession();
+    if (!open) {
+      console.log(chalk.yellow('No timer is currently running.'));
+      return;
+    }
+    const startTime = new Date(open.startedAt);
+    const duration = (new Date().getTime() - startTime.getTime()) / 1000;
+    const hours = Math.floor(duration / 3600);
+    const minutes = Math.floor((duration % 3600) / 60);
+    console.log(chalk.green('🕒 A timer is currently running (Jira-only mode).'));
+    if (open.jiraTicket) console.log(`   - ${chalk.bold('Jira:')} ${open.jiraTicket}`);
+    console.log(`   - ${chalk.bold('Description:')} ${open.description}`);
+    console.log(`   - ${chalk.bold('Running for:')} ${hours}h ${minutes}m`);
   });
 
 function sleep(ms: number) {

--- a/lib/credentials.test.ts
+++ b/lib/credentials.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'bun:test';
+import { isClockifyKeyValid } from './credentials.js';
+
+describe('isClockifyKeyValid', () => {
+  it('returns false when value is undefined', () => {
+    expect(isClockifyKeyValid(undefined)).toBe(false);
+  });
+
+  it('returns false when value is an empty string', () => {
+    expect(isClockifyKeyValid('')).toBe(false);
+  });
+
+  it('returns true when value is a non-empty string', () => {
+    expect(isClockifyKeyValid('abc123')).toBe(true);
+  });
+});

--- a/lib/credentials.ts
+++ b/lib/credentials.ts
@@ -9,3 +9,11 @@ export function resolveCredential(key: string): string | undefined {
 export function saveCredential(key: string, value: string) {
   setCredential(key, value);
 }
+
+export function isClockifyKeyValid(value: string | undefined): boolean {
+  return typeof value === 'string' && value.length > 0;
+}
+
+export function isClockifyEnabled(): boolean {
+  return isClockifyKeyValid(resolveCredential('CLOCKIFY_API_KEY'));
+}

--- a/lib/credentials.ts
+++ b/lib/credentials.ts
@@ -25,3 +25,11 @@ export function setClockifyDisabled(disabled: boolean) {
 export function isClockifyEnabled(): boolean {
   return isClockifyKeyValid(resolveCredential('CLOCKIFY_API_KEY')) && !isClockifyDisabled();
 }
+
+export function isJiraDisabled(): boolean {
+  return resolveCredential('JIRA_DISABLED') === '1';
+}
+
+export function setJiraDisabled(disabled: boolean) {
+  setCredential('JIRA_DISABLED', disabled ? '1' : '0');
+}

--- a/lib/credentials.ts
+++ b/lib/credentials.ts
@@ -14,6 +14,14 @@ export function isClockifyKeyValid(value: string | undefined): boolean {
   return typeof value === 'string' && value.length > 0;
 }
 
+export function isClockifyDisabled(): boolean {
+  return resolveCredential('CLOCKIFY_DISABLED') === '1';
+}
+
+export function setClockifyDisabled(disabled: boolean) {
+  setCredential('CLOCKIFY_DISABLED', disabled ? '1' : '0');
+}
+
 export function isClockifyEnabled(): boolean {
-  return isClockifyKeyValid(resolveCredential('CLOCKIFY_API_KEY'));
+  return isClockifyKeyValid(resolveCredential('CLOCKIFY_API_KEY')) && !isClockifyDisabled();
 }

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -231,9 +231,9 @@ export function getLastDescriptionByJiraTicket(jiraTicket: string): string | nul
   const db = getDb();
   const row = db
     .prepare(
-      "SELECT description FROM sessions WHERE jiraTicket = ? AND description IS NOT NULL AND description != '' ORDER BY startedAt DESC LIMIT 1",
+      "SELECT description FROM sessions WHERE jiraTicket = ? AND description IS NOT NULL AND description != '' AND description != ? ORDER BY startedAt DESC LIMIT 1",
     )
-    .get(jiraTicket) as { description: string } | undefined;
+    .get(jiraTicket, jiraTicket) as { description: string } | undefined;
   return row ? row.description : null;
 }
 

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -227,16 +227,6 @@ export function getSessionCount() {
   return row.count;
 }
 
-export function getLastDescriptionByJiraTicket(jiraTicket: string): string | null {
-  const db = getDb();
-  const row = db
-    .prepare(
-      "SELECT description FROM sessions WHERE jiraTicket = ? AND description IS NOT NULL AND description != '' AND description != ? ORDER BY startedAt DESC LIMIT 1",
-    )
-    .get(jiraTicket, jiraTicket) as { description: string } | undefined;
-  return row ? row.description : null;
-}
-
 export function getOpenSession() {
   const db = getDb();
   const stmt = db.prepare('SELECT * FROM sessions WHERE completedAt IS NULL ORDER BY startedAt DESC LIMIT 1');

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -21,7 +21,7 @@ if (!fs.existsSync(DB_DIR)) {
 
 const SessionSchema = z.object({
   id: z.string(),
-  projectId: z.string(),
+  projectId: z.string().nullable(),
   description: z.string(),
   startedAt: z.string(),
   completedAt: z.string().nullable(),
@@ -41,7 +41,7 @@ function getDb(): Database {
     dbInstance.exec(`
       CREATE TABLE IF NOT EXISTS sessions (
         id TEXT PRIMARY KEY,
-        projectId TEXT NOT NULL,
+        projectId TEXT,
         description TEXT NOT NULL,
         startedAt TEXT NOT NULL,
         completedAt TEXT,
@@ -54,6 +54,35 @@ function getDb(): Database {
     const sessionCols = dbInstance.prepare('PRAGMA table_info(sessions)').all() as Array<{ name: string }>;
     if (!sessionCols.some((c) => c.name === 'jiraWorklogId')) {
       dbInstance.exec('ALTER TABLE sessions ADD COLUMN jiraWorklogId TEXT');
+    }
+    // Migration: drop NOT NULL on sessions.projectId if it was created with the old schema
+    const projectIdCol = (sessionCols as Array<{ name: string; notnull: number }>).find((c) => c.name === 'projectId');
+    if (projectIdCol && projectIdCol.notnull === 1) {
+      dbInstance.exec('BEGIN');
+      try {
+        dbInstance.exec(`
+          CREATE TABLE sessions_new (
+            id TEXT PRIMARY KEY,
+            projectId TEXT,
+            description TEXT NOT NULL,
+            startedAt TEXT NOT NULL,
+            completedAt TEXT,
+            isAutoCompleted INTEGER DEFAULT 0,
+            jiraTicket TEXT,
+            jiraWorklogId TEXT
+          )
+        `);
+        dbInstance.exec(
+          'INSERT INTO sessions_new (id, projectId, description, startedAt, completedAt, isAutoCompleted, jiraTicket, jiraWorklogId) ' +
+            'SELECT id, projectId, description, startedAt, completedAt, isAutoCompleted, jiraTicket, jiraWorklogId FROM sessions',
+        );
+        dbInstance.exec('DROP TABLE sessions');
+        dbInstance.exec('ALTER TABLE sessions_new RENAME TO sessions');
+        dbInstance.exec('COMMIT');
+      } catch (err) {
+        dbInstance.exec('ROLLBACK');
+        throw err;
+      }
     }
     dbInstance.exec(`
       CREATE TABLE IF NOT EXISTS google_tokens (
@@ -127,7 +156,7 @@ export function getLatestToken() {
 
 export function logSessionStart(
   id: string,
-  projectId: string,
+  projectId: string | null,
   description: string,
   startedAt: string,
   jiraTicket?: string,
@@ -137,12 +166,12 @@ export function logSessionStart(
     'INSERT OR IGNORE INTO sessions (id, projectId, description, startedAt, isAutoCompleted, jiraTicket) VALUES (?, ?, ?, ?, ?, ?)',
   );
 
-  stmt.run(id, projectId, description, startedAt, 0, jiraTicket ?? null);
+  stmt.run(id, projectId ?? null, description, startedAt, 0, jiraTicket ?? null);
 }
 
 export function logCompletedSession(
   id: string,
-  projectId: string,
+  projectId: string | null,
   description: string,
   startedAt: string,
   completedAt: string,
@@ -152,7 +181,7 @@ export function logCompletedSession(
   const stmt = db.prepare(
     'INSERT OR IGNORE INTO sessions (id, projectId, description, startedAt, completedAt, isAutoCompleted, jiraTicket) VALUES (?, ?, ?, ?, ?, 0, ?)',
   );
-  stmt.run(id, projectId, description, startedAt, completedAt, jiraTicket ?? null);
+  stmt.run(id, projectId ?? null, description, startedAt, completedAt, jiraTicket ?? null);
 }
 
 export function completeLatestSession(completedAt: string, isAutoCompleted = false) {

--- a/lib/db.ts
+++ b/lib/db.ts
@@ -227,6 +227,16 @@ export function getSessionCount() {
   return row.count;
 }
 
+export function getLastDescriptionByJiraTicket(jiraTicket: string): string | null {
+  const db = getDb();
+  const row = db
+    .prepare(
+      "SELECT description FROM sessions WHERE jiraTicket = ? AND description IS NOT NULL AND description != '' ORDER BY startedAt DESC LIMIT 1",
+    )
+    .get(jiraTicket) as { description: string } | undefined;
+  return row ? row.description : null;
+}
+
 export function getOpenSession() {
   const db = getDb();
   const stmt = db.prepare('SELECT * FROM sessions WHERE completedAt IS NULL ORDER BY startedAt DESC LIMIT 1');

--- a/scripts/log-calendar-events.ts
+++ b/scripts/log-calendar-events.ts
@@ -62,6 +62,11 @@ if (!startDate || !endDate) {
 }
 
 async function main() {
+  const { isClockifyEnabled } = await import('../lib/credentials.js');
+  if (!isClockifyEnabled()) {
+    console.log('Calendar sync requires Clockify. Configure Clockify API key and re-run.');
+    return;
+  }
   const clockify = new Clockify();
   const user = await clockify.getUser();
 


### PR DESCRIPTION
## Summary
- Add Jira-only tracking mode: timer/monitor/CLI/dashboard run without Clockify when only Jira is configured
- Add local-only mode when neither provider is configured (DB-only logging)
- Independent Clockify and Jira enable/disable toggles in Settings (keys persist)
- Server-side Jira summary enrichment: `TICKET TITLE` saved in `sessions.description`
- Timer/monitor/calendar/CLI paths gated on `isClockifyEnabled` and `isJiraDisabled`
- UX: ticket description preview, Jira ticket field hidden when Jira off, local-only hint under description, custom right-click menu (Reload only)

## Test plan
- [ ] Clockify+Jira: start/stop timer, manual log, delete — entries sync both sides
- [ ] Clockify-only (Jira off): ticket field hidden, no Jira worklog calls
- [ ] Jira-only (Clockify off): description prefilled from ticket summary, worklog posts
- [ ] Local-only (both off): description-only timer, no network calls
- [ ] Toggle each provider off/on — UI + backend react immediately
- [ ] PM2 monitor idle stop still posts Jira worklog when Clockify off

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>